### PR TITLE
Feat/#6 메인 페이지

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -87,4 +87,8 @@ dependencies {
 
     // domain module
     implementation(project(":domain"))
+
+    // android core
+    implementation ("androidx.fragment:fragment-ktx:1.5.7")
+
 }

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/MainActivity.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/MainActivity.kt
@@ -2,11 +2,87 @@ package com.app.edonymyeon.presentation.ui.main
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
 import app.edonymyeon.R
+import app.edonymyeon.databinding.ActivityMainBinding
+import com.app.edonymyeon.presentation.ui.main.alarm.AlarmFragment
+import com.app.edonymyeon.presentation.ui.main.category.CategoryFragment
+import com.app.edonymyeon.presentation.ui.main.home.HomeFragment
+import com.app.edonymyeon.presentation.ui.main.mypage.MyPageFragment
+import com.app.edonymyeon.presentation.ui.main.search.SearchFragment
 
 class MainActivity : AppCompatActivity() {
+    private val fragments = mapOf(
+        FRAGMENT_SEARCH to SearchFragment(),
+        FRAGMENT_CATEGORY to CategoryFragment(),
+        FRAGMENT_HOME to HomeFragment(),
+        FRAGMENT_ALARM to AlarmFragment(),
+        FRAGMENT_MY_PAGE to MyPageFragment(),
+    )
+
+    private val binding: ActivityMainBinding by lazy {
+        ActivityMainBinding.inflate(layoutInflater)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        setContentView(binding.root)
+
+        initFragmentContainerView()
+        setBottomNavigationView()
+    }
+
+    private fun initFragmentContainerView() {
+        supportFragmentManager.commit {
+            add(R.id.fcv_main, HomeFragment(), FRAGMENT_HOME)
+            setReorderingAllowed(true)
+        }
+    }
+
+    private fun setBottomNavigationView() {
+        binding.bnvMain.selectedItemId = R.id.bottom_menu_home
+        binding.bnvMain.setOnItemSelectedListener { selectedIcon ->
+            changeFragment(getTag(selectedIcon.itemId))
+            true
+        }
+    }
+
+    private fun changeFragment(tag: String) {
+        hideShowingFragment()
+
+        val findFragment = supportFragmentManager.findFragmentByTag(tag)
+        supportFragmentManager.commit {
+            if (findFragment != null) {
+                show(findFragment)
+            } else {
+                val fragment: Fragment = fragments[tag] ?: throw IllegalArgumentException()
+                add(R.id.fcv_main, fragment, tag)
+            }
+        }
+    }
+
+    private fun hideShowingFragment() {
+        val currentTag = getTag(binding.bnvMain.selectedItemId)
+        supportFragmentManager.commit {
+            supportFragmentManager.findFragmentByTag(currentTag)?.let { hide(it) }
+        }
+    }
+
+    private fun getTag(itemId: Int): String = when (itemId) {
+        R.id.bottom_menu_search -> FRAGMENT_SEARCH
+        R.id.bottom_menu_category -> FRAGMENT_CATEGORY
+        R.id.bottom_menu_home -> FRAGMENT_HOME
+        R.id.bottom_menu_alarm -> FRAGMENT_ALARM
+        R.id.bottom_menu_my_page -> FRAGMENT_MY_PAGE
+        else -> throw IllegalArgumentException()
+    }
+
+    companion object {
+        private const val FRAGMENT_SEARCH = "search"
+        private const val FRAGMENT_CATEGORY = "category"
+        private const val FRAGMENT_HOME = "home"
+        private const val FRAGMENT_ALARM = "alarm"
+        private const val FRAGMENT_MY_PAGE = "myPage"
     }
 }

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/MainAdapter.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/MainAdapter.kt
@@ -1,4 +1,0 @@
-package com.app.edonymyeon.presentation.ui.main
-
-class MainAdapter {
-}

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/alarm/AlarmFragment.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/alarm/AlarmFragment.kt
@@ -1,0 +1,18 @@
+package com.app.edonymyeon.presentation.ui.main.alarm
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import app.edonymyeon.R
+
+class AlarmFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_preparing_page, container, false)
+    }
+}

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/category/CategoryFragment.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/category/CategoryFragment.kt
@@ -1,0 +1,17 @@
+package com.app.edonymyeon.presentation.ui.main.category
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import app.edonymyeon.R
+
+class CategoryFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_preparing_page, container, false)
+    }
+}

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/home/HomeFragment.kt
@@ -1,0 +1,18 @@
+package com.app.edonymyeon.presentation.ui.main.home
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import app.edonymyeon.R
+
+class HomeFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_home, container, false)
+    }
+}

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/mypage/MyPageFragment.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/mypage/MyPageFragment.kt
@@ -1,0 +1,18 @@
+package com.app.edonymyeon.presentation.ui.main.mypage
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import app.edonymyeon.R
+
+class MyPageFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_my_page, container, false)
+    }
+}

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/search/SearchFragment.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/search/SearchFragment.kt
@@ -1,0 +1,18 @@
+package com.app.edonymyeon.presentation.ui.main.search
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import app.edonymyeon.R
+
+class SearchFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_preparing_page, container, false)
+    }
+}

--- a/android/app/src/main/res/drawable/ic_bottom_nav_alarm.xml
+++ b/android/app/src/main/res/drawable/ic_bottom_nav_alarm.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="36dp"
+    android:viewportWidth="36"
+    android:viewportHeight="36">
+  <path
+      android:pathData="M18,33C19.65,33 21,31.65 21,30H15C15,31.65 16.335,33 18,33ZM27,24V16.5C27,11.895 24.54,8.04 20.25,7.02V6C20.25,4.755 19.245,3.75 18,3.75C16.755,3.75 15.75,4.755 15.75,6V7.02C11.445,8.04 9,11.88 9,16.5V24L6,27V28.5H30V27L27,24Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_bottom_nav_category.xml
+++ b/android/app/src/main/res/drawable/ic_bottom_nav_category.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="36dp"
+    android:viewportWidth="36"
+    android:viewportHeight="36">
+  <group>
+    <clip-path
+        android:pathData="M0,0h36v36h-36z"/>
+    <path
+        android:pathData="M4.5,27H31.5V24H4.5V27ZM4.5,19.5H31.5V16.5H4.5V19.5ZM4.5,9V12H31.5V9H4.5Z"
+        android:fillColor="#ffffff"/>
+  </group>
+</vector>

--- a/android/app/src/main/res/drawable/ic_bottom_nav_home.xml
+++ b/android/app/src/main/res/drawable/ic_bottom_nav_home.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="36dp"
+    android:viewportWidth="36"
+    android:viewportHeight="36">
+  <group>
+    <clip-path
+        android:pathData="M0,0h36v36h-36z"/>
+    <path
+        android:pathData="M15,30V21H21V30H28.5V18H33L18,4.5L3,18H7.5V30H15Z"
+        android:fillColor="#ffffff"/>
+  </group>
+</vector>

--- a/android/app/src/main/res/drawable/ic_bottom_nav_my_page.xml
+++ b/android/app/src/main/res/drawable/ic_bottom_nav_my_page.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="36dp"
+    android:viewportWidth="36"
+    android:viewportHeight="36">
+  <group>
+    <clip-path
+        android:pathData="M0,0h36v36h-36z"/>
+    <path
+        android:pathData="M18,3C9.72,3 3,9.72 3,18C3,26.28 9.72,33 18,33C26.28,33 33,26.28 33,18C33,9.72 26.28,3 18,3ZM18,7.5C20.49,7.5 22.5,9.51 22.5,12C22.5,14.49 20.49,16.5 18,16.5C15.51,16.5 13.5,14.49 13.5,12C13.5,9.51 15.51,7.5 18,7.5ZM18,28.8C14.25,28.8 10.935,26.88 9,23.97C9.045,20.985 15,19.35 18,19.35C20.985,19.35 26.955,20.985 27,23.97C25.065,26.88 21.75,28.8 18,28.8Z"
+        android:fillColor="#ffffff"/>
+  </group>
+</vector>

--- a/android/app/src/main/res/drawable/ic_bottom_nav_search.xml
+++ b/android/app/src/main/res/drawable/ic_bottom_nav_search.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="36dp"
+    android:viewportWidth="36"
+    android:viewportHeight="36">
+  <group>
+    <clip-path
+        android:pathData="M0,0h36v36h-36z"/>
+    <path
+        android:pathData="M23.25,21H22.065L21.645,20.595C23.115,18.885 24,16.665 24,14.25C24,8.865 19.635,4.5 14.25,4.5C8.865,4.5 4.5,8.865 4.5,14.25C4.5,19.635 8.865,24 14.25,24C16.665,24 18.885,23.115 20.595,21.645L21,22.065V23.25L28.5,30.735L30.735,28.5L23.25,21ZM14.25,21C10.515,21 7.5,17.985 7.5,14.25C7.5,10.515 10.515,7.5 14.25,7.5C17.985,7.5 21,10.515 21,14.25C21,17.985 17.985,21 14.25,21Z"
+        android:fillColor="#ffffff"/>
+  </group>
+</vector>

--- a/android/app/src/main/res/drawable/selector_bottom_nav_icon_tint.xml
+++ b/android/app/src/main/res/drawable/selector_bottom_nav_icon_tint.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Selected state -->
+    <item android:color="@color/white" android:state_checked="true" />
+    <!-- Unselected state -->
+    <item android:color="@color/gray_b0b9d1" />
+</selector>

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -1,18 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context="com.app.edonymyeon.presentation.ui.main.MainActivity">
+<layout xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context="com.app.edonymyeon.presentation.ui.main.MainActivity">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/fcv_main"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toTopOf="@id/bnv_main"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.bottomnavigation.BottomNavigationView
+            android:id="@+id/bnv_main"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@color/blue_576b9e"
+            app:itemIconSize="36dp"
+            app:itemIconTint="@drawable/selector_bottom_nav_icon_tint"
+            app:labelVisibilityMode="unlabeled"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="H,360:56"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:menu="@menu/bottom_menu" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/fragment_alarm.xml
+++ b/android/app/src/main/res/layout/fragment_alarm.xml
@@ -1,0 +1,5 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</FrameLayout>

--- a/android/app/src/main/res/layout/fragment_category.xml
+++ b/android/app/src/main/res/layout/fragment_category.xml
@@ -1,0 +1,5 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</FrameLayout>

--- a/android/app/src/main/res/layout/fragment_home.xml
+++ b/android/app/src/main/res/layout/fragment_home.xml
@@ -1,0 +1,5 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</FrameLayout>

--- a/android/app/src/main/res/layout/fragment_my_page.xml
+++ b/android/app/src/main/res/layout/fragment_my_page.xml
@@ -1,0 +1,7 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.app.edonymyeon.presentation.ui.main.home.HomeFragment">
+
+</FrameLayout>

--- a/android/app/src/main/res/layout/fragment_preparing_page.xml
+++ b/android/app/src/main/res/layout/fragment_preparing_page.xml
@@ -1,0 +1,16 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.app.edonymyeon.presentation.ui.main.home.HomeFragment">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fontFamily="@font/dohyeon"
+        android:gravity="center"
+        android:text="@string/all_preparing_page"
+        android:textColor="@color/black_000000"
+        android:textSize="35sp" />
+
+</FrameLayout>

--- a/android/app/src/main/res/layout/fragment_search.xml
+++ b/android/app/src/main/res/layout/fragment_search.xml
@@ -1,0 +1,11 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="search" />
+
+</FrameLayout>

--- a/android/app/src/main/res/menu/bottom_menu.xml
+++ b/android/app/src/main/res/menu/bottom_menu.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/bottom_menu_search"
+        android:icon="@drawable/ic_bottom_nav_search"
+        android:title="@string/bottom_navigation_search_title" />
+
+    <item
+        android:id="@+id/bottom_menu_category"
+        android:icon="@drawable/ic_bottom_nav_category"
+        android:title="@string/bottom_navigation_category_title" />
+
+    <item
+        android:id="@+id/bottom_menu_home"
+        android:icon="@drawable/ic_bottom_nav_home"
+        android:title="@string/bottom_navigation_home_title" />
+
+    <item
+        android:id="@+id/bottom_menu_alarm"
+        android:icon="@drawable/ic_bottom_nav_alarm"
+        android:title="@string/bottom_navigation_alarm_title" />
+
+    <item
+        android:id="@+id/bottom_menu_my_page"
+        android:icon="@drawable/ic_bottom_nav_my_page"
+        android:title="@string/bottom_navigation_my_page_title" />
+</menu>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -5,4 +5,5 @@
     <color name="black_000000">#000000</color>
     <color name="white_ffffff">#ffffff</color>
     <color name="blue_576b9e">#576B9E</color>
+    <color name="gray_b0b9d1">#B0B9D1</color>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -9,4 +9,11 @@
     <string name="login_login">로그인</string>
     <string name="login_suggest">아이디가 없나요?</string>
     <string name="login_join">회원가입</string>
+
+    <!-- bottom navigation title    -->
+    <string name="bottom_navigation_home_title">홈</string>
+    <string name="bottom_navigation_search_title">검색</string>
+    <string name="bottom_navigation_category_title">카테고리</string>
+    <string name="bottom_navigation_alarm_title">알림</string>
+    <string name="bottom_navigation_my_page_title">마이 페이지</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -16,4 +16,5 @@
     <string name="bottom_navigation_category_title">카테고리</string>
     <string name="bottom_navigation_alarm_title">알림</string>
     <string name="bottom_navigation_my_page_title">마이 페이지</string>
+    <string name="all_preparing_page">준비중인 페이지입니다</string>
 </resources>


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #6

## 📝 작업 요약

바텀 네비게이션 구현 및 프레그먼트 연결

## 🔎 작업 상세 설명

바텀 네비게이션을 show/hide 방식으로 구현, 2차 데모데이 때 발표할 프레그먼트 외에 준비 중인 페이지 TextView를 출력하도록 함
build.gradle에 fragment-ktx 추가(commit 등 프레그먼트 트랜젝션 명령어를 간단하게 사용가능)

## 🌟 리뷰 요구 사항

MainActivity 위주로 봐주시면 좋을 것 같습니다:) ViewModel등 라이브러리를 활용한 더 좋은 방안도 있을까요..?