### PR TITLE
feat: Member 로그인 기능 구현

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/controller/AuthController.java
+++ b/backend/src/main/java/edonymyeon/backend/controller/AuthController.java
@@ -1,0 +1,27 @@
+package edonymyeon.backend.controller;
+
+import edonymyeon.backend.service.AuthenticationService;
+import edonymyeon.backend.service.request.LoginRequest;
+import java.util.Base64;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class AuthController {
+
+    private final AuthenticationService authenticationService;
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(@RequestBody LoginRequest loginRequest) {
+        authenticationService.findMember(loginRequest);
+
+        String valueToEncode = loginRequest.email() + ":" + loginRequest.password();
+        final String cookie = "Basic " + Base64.getEncoder().encodeToString(valueToEncode.getBytes());
+        return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie).build();
+    }
+}

--- a/backend/src/main/java/edonymyeon/backend/domain/Member.java
+++ b/backend/src/main/java/edonymyeon/backend/domain/Member.java
@@ -1,0 +1,34 @@
+package edonymyeon.backend.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    private String introduction;
+
+    //todo: 프로필 사진
+    //todo: 검증 로직
+}

--- a/backend/src/main/java/edonymyeon/backend/domain/exception/ExceptionCode.java
+++ b/backend/src/main/java/edonymyeon/backend/domain/exception/ExceptionCode.java
@@ -8,9 +8,14 @@ import lombok.Getter;
 public enum ExceptionCode {
 
     // 클래스이름_필드명_틀린내용
-    POST_TITLE_ILLEGAL_LENGTH(1511, "제목은 1자 이상 30자 이하여야 합니다."),
-    POST_CONTENT_ILLEGAL_LENGTH(1523, "내용은 1자 이상 1,000자 이하여야 합니다."),
-    POST_PRICE_ILLEGAL_SIZE(1543, "가격은 0원 이상 100억 이하여야 합니다.");
+    // 1___: 인증 관련
+    MEMBER_EMAIL_NOT_FOUND(1511, "회원의 이메일이 존재하지 않습니다."),
+    AUTHORIZATION_EMPTY(1523, "인증 정보가 없습니다."),
+
+    // 2___: 게시글 관련
+    POST_TITLE_ILLEGAL_LENGTH(2511, "제목은 1자 이상 30자 이하여야 합니다."),
+    POST_CONTENT_ILLEGAL_LENGTH(2523, "내용은 1자 이상 1,000자 이하여야 합니다."),
+    POST_PRICE_ILLEGAL_SIZE(2543, "가격은 0원 이상 100억 이하여야 합니다.");
 
     private int code;
     private String message;

--- a/backend/src/main/java/edonymyeon/backend/repository/MemberRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package edonymyeon.backend.repository;
+
+import edonymyeon.backend.domain.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmailAndPassword(final String email, final String password);
+}

--- a/backend/src/main/java/edonymyeon/backend/service/AuthenticationService.java
+++ b/backend/src/main/java/edonymyeon/backend/service/AuthenticationService.java
@@ -1,0 +1,29 @@
+package edonymyeon.backend.service;
+
+import static edonymyeon.backend.domain.exception.ExceptionCode.MEMBER_EMAIL_NOT_FOUND;
+
+import edonymyeon.backend.domain.Member;
+import edonymyeon.backend.domain.exception.EdonymyeonException;
+import edonymyeon.backend.repository.MemberRepository;
+import edonymyeon.backend.service.request.LoginRequest;
+import edonymyeon.backend.service.response.MemberIdDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AuthenticationService {
+
+    private final MemberRepository memberRepository;
+
+    //todo: 비밀번호까지 조회에 사용하나?
+    public MemberIdDto findMember(final String email, final String password) {
+        final Member member = memberRepository.findByEmailAndPassword(email, password)
+                .orElseThrow(() -> new EdonymyeonException(MEMBER_EMAIL_NOT_FOUND));
+        return new MemberIdDto(member.getId());
+    }
+
+    public MemberIdDto findMember(final LoginRequest loginRequest) {
+        return findMember(loginRequest.email(), loginRequest.password());
+    }
+}

--- a/backend/src/main/java/edonymyeon/backend/service/request/LoginRequest.java
+++ b/backend/src/main/java/edonymyeon/backend/service/request/LoginRequest.java
@@ -1,0 +1,5 @@
+package edonymyeon.backend.service.request;
+
+public record LoginRequest(String email, String password) {
+
+}

--- a/backend/src/main/java/edonymyeon/backend/service/response/MemberIdDto.java
+++ b/backend/src/main/java/edonymyeon/backend/service/response/MemberIdDto.java
@@ -1,0 +1,5 @@
+package edonymyeon.backend.service.response;
+
+public record MemberIdDto(Long id) {
+
+}


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #5 

## 📝 작업 요약
로그인 기능 구현

## 🔎 작업 상세 설명
로그인 시, 사용자의 이메일과 비밀번호를 받는다.
해당하는 사용자가 있는지 확인한다.
사용자 정보로 Basic 인증정보를 쿠키에 담는다.
