### PR TITLE
feat/#55 게시글에 작성자 정보를 저장하는 기능 구현

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/global/exception/ExceptionInformation.java
+++ b/backend/src/main/java/edonymyeon/backend/global/exception/ExceptionInformation.java
@@ -15,7 +15,11 @@ public enum ExceptionInformation {
     // 2___: 게시글 관련
     POST_TITLE_ILLEGAL_LENGTH(2511, "제목은 1자 이상 30자 이하여야 합니다."),
     POST_CONTENT_ILLEGAL_LENGTH(2523, "내용은 1자 이상 1,000자 이하여야 합니다."),
-    POST_PRICE_ILLEGAL_SIZE(2543, "가격은 0원 이상 100억 이하여야 합니다.");
+    POST_PRICE_ILLEGAL_SIZE(2543, "가격은 0원 이상 100억 이하여야 합니다."),
+    POST_MEMBER_EMPTY(2544, "게시글에는 작성자가 있어야 합니다."),
+
+    // 3___: 회원 관련
+    MEMBER_ID_NOT_FOUND(3000, "존재하지 않는 회원입니다.");
 
     private int code;
 

--- a/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
+++ b/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
@@ -10,10 +10,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Member {

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
@@ -1,9 +1,15 @@
 package edonymyeon.backend.post.application;
 
+import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_ID_NOT_FOUND;
+
+import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.image.ImageFileUploader;
 import edonymyeon.backend.image.domain.ImageInfo;
 import edonymyeon.backend.image.postimage.PostImageInfoRepository;
 import edonymyeon.backend.image.postimage.domain.PostImageInfo;
+import edonymyeon.backend.member.application.dto.MemberIdDto;
+import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.application.dto.PostRequest;
 import edonymyeon.backend.post.application.dto.PostResponse;
 import edonymyeon.backend.post.domain.Post;
@@ -20,15 +26,23 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostService {
 
     private final PostRepository postRepository;
+
     private final ImageFileUploader imageFileUploader;
+
     private final PostImageInfoRepository postImageInfoRepository;
 
+    private final MemberRepository memberRepository;
+
     @Transactional
-    public PostResponse createPost(final PostRequest postRequest) {
+    public PostResponse createPost(final MemberIdDto memberIdDto, final PostRequest postRequest) {
+        final Member member = memberRepository.findById(memberIdDto.id())
+                .orElseThrow(() -> new EdonymyeonException(MEMBER_ID_NOT_FOUND));
+
         final Post post = new Post(
                 postRequest.title(),
                 postRequest.content(),
-                postRequest.price()
+                postRequest.price(),
+                member
         );
         postRepository.save(post);
 

--- a/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
+++ b/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
@@ -1,17 +1,22 @@
 package edonymyeon.backend.post.domain;
 
 import static edonymyeon.backend.global.exception.ExceptionInformation.POST_CONTENT_ILLEGAL_LENGTH;
+import static edonymyeon.backend.global.exception.ExceptionInformation.POST_MEMBER_EMPTY;
 import static edonymyeon.backend.global.exception.ExceptionInformation.POST_PRICE_ILLEGAL_SIZE;
 import static edonymyeon.backend.global.exception.ExceptionInformation.POST_TITLE_ILLEGAL_LENGTH;
 
 import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.image.postimage.domain.PostImageInfo;
+import edonymyeon.backend.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -50,7 +55,10 @@ public class Post {
     @Column(nullable = false)
     private Long price;
 
-    // TODO: 작성자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private Member member;
+
     // TODO: cascade
     @OneToMany(mappedBy = "post")
     private List<PostImageInfo> postImageInfos;
@@ -65,23 +73,27 @@ public class Post {
     public Post(
             final String title,
             final String content,
-            final Long price
+            final Long price,
+            final Member member
     ) {
-        validate(title, content, price);
+        validate(title, content, price, member);
         this.title = title;
         this.content = content;
         this.price = price;
+        this.member = member;
         this.postImageInfos = new ArrayList<>();
     }
 
     private void validate(
             final String title,
             final String content,
-            final Long price
+            final Long price,
+            final Member member
     ) {
         validateTitle(title);
         validateContent(content);
         validatePrice(price);
+        validateMember(member);
     }
 
     private void validateTitle(final String title) {
@@ -99,6 +111,12 @@ public class Post {
     private void validatePrice(final Long price) {
         if (Objects.isNull(price) || price < MIN_PRICE || price > MAX_PRICE) {
             throw new EdonymyeonException(POST_PRICE_ILLEGAL_SIZE);
+        }
+    }
+
+    private void validateMember(final Member member) {
+        if (Objects.isNull(member)) {
+            throw new EdonymyeonException(POST_MEMBER_EMPTY);
         }
     }
 

--- a/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
+++ b/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
@@ -67,8 +67,9 @@ public class Post {
     @Column(nullable = false)
     private LocalDateTime createAt;
 
+    // todo: 테스트 코드에서 자꾸 null 값으로 조회되서 일단 하드코딩
     @ColumnDefault("0")
-    private Long viewCount;
+    private Long viewCount = 0L;
 
     public Post(
             final String title,

--- a/backend/src/main/java/edonymyeon/backend/post/ui/PostController.java
+++ b/backend/src/main/java/edonymyeon/backend/post/ui/PostController.java
@@ -23,7 +23,7 @@ public class PostController {
     @PostMapping
     public ResponseEntity<PostResponse> createPost(@AuthPrincipal MemberIdDto memberId,
                                                    @ModelAttribute PostRequest postRequest) {
-        PostResponse response = postService.createPost(postRequest);
+        PostResponse response = postService.createPost(memberId, postRequest);
         return ResponseEntity.created(URI.create("/posts/" + response.id()))
                 .body(response);
     }

--- a/backend/src/test/java/edonymyeon/backend/repository/PostRepositoryTest.java
+++ b/backend/src/test/java/edonymyeon/backend/repository/PostRepositoryTest.java
@@ -14,39 +14,47 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.test.context.TestConstructor.AutowireMode;
-import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 @SuppressWarnings("NonAsciiCharacters")
-@Sql("/dummydata.sql")
 @RequiredArgsConstructor
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 @SpringBootTest
 class PostRepositoryTest {
 
-    private final PostRepository posts;
+    private final PostRepository postRepository;
 
-    private final MemberRepository members;
-
+    private final MemberRepository memberRepository;
     private Member member;
 
     @BeforeEach
     public void setUp() {
-        this.member = members.findById(1L).get();
+        member = new Member(
+                null,
+                "email",
+                "password",
+                "nickname",
+                "introduction",
+                null
+        );
+        memberRepository.save(member);
     }
 
     @Test
     void 생성() {
         Post post = new Post("호바", "호이 바보라는 뜻", 0L, member);
-        posts.save(post);
+        postRepository.save(post);
 
-        Post target = posts.findById(post.getId()).get();
+        Post target = postRepository.findById(post.getId()).get();
 
         assertSoftly(softly -> {
                     softly.assertThat(target.getId()).isNotNull();
                     softly.assertThat(target.getTitle()).isEqualTo("호바");
                     softly.assertThat(target.getCreateAt()).isNotNull();
-                    softly.assertThat(target.getViewCount()).isEqualTo(0);
+                    softly.assertThat(target.getViewCount()).isEqualTo(0L);
+                    softly.assertThat(target.getMember().getId()).isEqualTo(1L);
                 }
         );
     }

--- a/backend/src/test/java/edonymyeon/backend/repository/PostRepositoryTest.java
+++ b/backend/src/test/java/edonymyeon/backend/repository/PostRepositoryTest.java
@@ -2,16 +2,23 @@ package edonymyeon.backend.repository;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
+import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.test.context.TestConstructor.AutowireMode;
+import org.springframework.test.context.jdbc.Sql;
 
 @SuppressWarnings("NonAsciiCharacters")
+@Sql("/dummydata.sql")
+@RequiredArgsConstructor
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
 @SpringBootTest
@@ -19,13 +26,18 @@ class PostRepositoryTest {
 
     private final PostRepository posts;
 
-    PostRepositoryTest(final PostRepository posts) {
-        this.posts = posts;
+    private final MemberRepository members;
+
+    private Member member;
+
+    @BeforeEach
+    public void setUp() {
+        this.member = members.findById(1L).get();
     }
 
     @Test
     void 생성() {
-        Post post = new Post("호바", "호이 바보라는 뜻", 0L);
+        Post post = new Post("호바", "호이 바보라는 뜻", 0L, member);
         posts.save(post);
 
         Post target = posts.findById(post.getId()).get();

--- a/backend/src/test/java/edonymyeon/backend/service/PostServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/service/PostServiceTest.java
@@ -8,6 +8,7 @@ import edonymyeon.backend.image.domain.ImageInfo;
 import edonymyeon.backend.image.postimage.PostImageInfoRepository;
 import edonymyeon.backend.image.postimage.domain.PostImageInfo;
 import edonymyeon.backend.member.application.dto.MemberIdDto;
+import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.application.PostService;
 import edonymyeon.backend.post.application.dto.PostRequest;
@@ -17,6 +18,7 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -25,11 +27,11 @@ import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.test.context.TestConstructor.AutowireMode;
-import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+@Transactional
 @SuppressWarnings("NonAsciiCharacters")
-@Sql("/dummydata.sql")
 @RequiredArgsConstructor
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
@@ -37,13 +39,27 @@ import org.springframework.web.multipart.MultipartFile;
 @SpringBootTest
 class PostServiceTest {
 
-    private static final MemberIdDto memberId = new MemberIdDto(1L);
-
     private final PostImageInfoRepository postImageInfoRepository;
 
     private final PostService postService;
 
     private final MemberRepository memberRepository;
+
+    private MemberIdDto memberId;
+
+    @BeforeEach
+    public void setUp() {
+        Member member = new Member(
+                null,
+                "email",
+                "password",
+                "nickname",
+                "introduction",
+                null
+        );
+        memberRepository.save(member);
+        memberId = new MemberIdDto(member.getId());
+    }
 
     @Test
     void 게시글_생성() {
@@ -64,6 +80,8 @@ class PostServiceTest {
         final PostRequest postRequest = getPostRequest();
 
         // when
+        System.out.println("폴더에_저장하는_이미지의_이름은_UUID_와_확장자명_형식으로_지어진다");
+        System.out.println("memberId.id() = " + memberId.id());
         final var postId = postService.createPost(memberId, postRequest).id();
 
         // then
@@ -84,6 +102,8 @@ class PostServiceTest {
         final PostRequest postRequest = getPostRequest();
 
         // when
+        System.out.println("폴더에_이미지를_저장한_후_Post_도메인에는_파일의_경로를_넘긴다");
+        System.out.println("memberId.id() = " + memberId.id());
         final Long postId = postService.createPost(memberId, postRequest).id();
 
         // then
@@ -125,6 +145,8 @@ class PostServiceTest {
                 null
         );
 
+        System.out.println("이미지가 없어도 게시글 저장 가능");
+        System.out.println("memberId.id() = " + memberId.id());
         assertThatCode(() -> postService.createPost(memberId, postRequest)).doesNotThrowAnyException();
     }
 }

--- a/backend/src/test/java/edonymyeon/backend/service/PostServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/service/PostServiceTest.java
@@ -7,6 +7,8 @@ import edonymyeon.backend.TestConfig;
 import edonymyeon.backend.image.domain.ImageInfo;
 import edonymyeon.backend.image.postimage.PostImageInfoRepository;
 import edonymyeon.backend.image.postimage.domain.PostImageInfo;
+import edonymyeon.backend.member.application.dto.MemberIdDto;
+import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.application.PostService;
 import edonymyeon.backend.post.application.dto.PostRequest;
 import edonymyeon.backend.post.application.dto.PostResponse;
@@ -23,9 +25,11 @@ import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.test.context.TestConstructor.AutowireMode;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.web.multipart.MultipartFile;
 
 @SuppressWarnings("NonAsciiCharacters")
+@Sql("/dummydata.sql")
 @RequiredArgsConstructor
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
@@ -33,8 +37,13 @@ import org.springframework.web.multipart.MultipartFile;
 @SpringBootTest
 class PostServiceTest {
 
+    private static final MemberIdDto memberId = new MemberIdDto(1L);
+
     private final PostImageInfoRepository postImageInfoRepository;
+
     private final PostService postService;
+
+    private final MemberRepository memberRepository;
 
     @Test
     void 게시글_생성() {
@@ -45,7 +54,7 @@ class PostServiceTest {
                 Collections.emptyList()
         );
 
-        final PostResponse target = postService.createPost(request);
+        final PostResponse target = postService.createPost(memberId, request);
         assertThat(target.id()).isNotNull();
     }
 
@@ -55,7 +64,7 @@ class PostServiceTest {
         final PostRequest postRequest = getPostRequest();
 
         // when
-        final var postId = postService.createPost(postRequest).id();
+        final var postId = postService.createPost(memberId, postRequest).id();
 
         // then
         List<PostImageInfo> imageFiles = postImageInfoRepository.findAllByPostId(postId);
@@ -75,7 +84,7 @@ class PostServiceTest {
         final PostRequest postRequest = getPostRequest();
 
         // when
-        final Long postId = postService.createPost(postRequest).id();
+        final Long postId = postService.createPost(memberId, postRequest).id();
 
         // then
         List<PostImageInfo> imageFiles = postImageInfoRepository.findAllByPostId(postId);
@@ -116,6 +125,6 @@ class PostServiceTest {
                 null
         );
 
-        assertThatCode(() -> postService.createPost(postRequest)).doesNotThrowAnyException();
+        assertThatCode(() -> postService.createPost(memberId, postRequest)).doesNotThrowAnyException();
     }
 }

--- a/backend/src/test/resources/dummydata.sql
+++ b/backend/src/test/resources/dummydata.sql
@@ -1,2 +1,2 @@
-insert into Member
-values (default, 'email', '', '', 'password');
+insert into Member (id, email, introduction, nickname, password, profile_image_info_id)
+values (default, 'email', '', '', 'password', null);


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #55 

## 📝 작업 요약

게시글 작성 요청 시에 들어오는 회원 정보(Member)를 게시글(Post)에 저장하여 게시글의 작성자가 누구인지 알 수 있게 구현

## 🔎 작업 상세 설명

서비스에서 Dto를 통해 들어오는 회원 id를 이용해 회원 정보를 조회
- `서비스에서 서비스를 참조하는 구조`(PostService에서 회원 id로 member를 가져오기 위해 MemberService를 이용)를 아직 서비스가 미완성된 상태라 사용할 수 없어서, 일단 PostService에서 MemberRepository를 통해 member를 가져오도록 하였습니다. 
- ExceptionInformation에 enum 추가하였습니다.

Post - Member 관계를 `@ManyToOne으로 설정`
- 그렇습니다.

깨지는 테스트 코드 수정
- 테스트용 ddl 파일 및 깨지는 테스트 코드를 수정하였습니다.

## 🌟 리뷰 요구 사항
> Dto에 @NotNull을 붙여주는 것이 어떨까요?! 서비스에서 MemberIdDto 값이 null인 것을 검증하는 로직을 넣으려다가 남겨두었습니다.
