### PR TITLE
feat/#13 게시글 추천 기능구현 

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/global/exception/ExceptionInformation.java
+++ b/backend/src/main/java/edonymyeon/backend/global/exception/ExceptionInformation.java
@@ -19,7 +19,11 @@ public enum ExceptionInformation {
     POST_MEMBER_EMPTY(2544, "게시글에는 작성자가 있어야 합니다."),
 
     // 3___: 회원 관련
-    MEMBER_ID_NOT_FOUND(3000, "존재하지 않는 회원입니다.");
+    MEMBER_ID_NOT_FOUND(3000, "존재하지 않는 회원입니다."),
+
+    // 4___: 추천 관련
+    THUMBS_UP_ALREADY_EXIST(4000, "이미 추천된 게시글 입니다"),
+    THUMBS_POST_IS_LOGIN_MEMBER(4001, "본인의 게시글을 추천/비추천 할 수 없습니다");
 
     private int code;
 

--- a/backend/src/main/java/edonymyeon/backend/thumbs/application/ThumbsService.java
+++ b/backend/src/main/java/edonymyeon/backend/thumbs/application/ThumbsService.java
@@ -1,0 +1,58 @@
+package edonymyeon.backend.thumbs.application;
+
+import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_ID_NOT_FOUND;
+import static edonymyeon.backend.global.exception.ExceptionInformation.THUMBS_POST_IS_LOGIN_MEMBER;
+import static edonymyeon.backend.global.exception.ExceptionInformation.THUMBS_UP_ALREADY_EXIST;
+
+import edonymyeon.backend.global.exception.EdonymyeonException;
+import edonymyeon.backend.member.application.dto.MemberIdDto;
+import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.repository.MemberRepository;
+import edonymyeon.backend.post.domain.Post;
+import edonymyeon.backend.post.repository.PostRepository;
+import edonymyeon.backend.thumbs.domain.Thumbs;
+import edonymyeon.backend.thumbs.domain.ThumbsType;
+import edonymyeon.backend.thumbs.repository.ThumbsRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ThumbsService {
+
+    private final ThumbsRepository thumbsRepository;
+
+    // TODO: 나중에 dev 받아와서 서비스들로 고쳐주기
+    private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+
+    public void thumbsUp(final MemberIdDto memberId, final Long postId) {
+        Member loginMember = memberRepository.findById(memberId.id())
+                .orElseThrow(() -> new EdonymyeonException(MEMBER_ID_NOT_FOUND));
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 게시글이 없습니다."));
+
+        // TODO: equal재정의 되면 바꿔주기
+        if (post.getMember().getId().equals(loginMember.getId())) {
+            throw new EdonymyeonException(THUMBS_POST_IS_LOGIN_MEMBER);
+        }
+
+        Optional<Thumbs> postThumbs = thumbsRepository.findByPostIdAndMemberId(postId, loginMember.getId());
+
+        if (postThumbs.isEmpty()) {
+            Thumbs thumbs = new Thumbs(post, loginMember, ThumbsType.UP);
+            thumbsRepository.save(thumbs);
+            return;
+        }
+
+        Thumbs thumbs = postThumbs.get();
+
+        if (thumbs.isUp()) {
+            throw new EdonymyeonException(THUMBS_UP_ALREADY_EXIST);
+        }
+
+        thumbs.updateThumbsType();
+    }
+}

--- a/backend/src/main/java/edonymyeon/backend/thumbs/application/ThumbsService.java
+++ b/backend/src/main/java/edonymyeon/backend/thumbs/application/ThumbsService.java
@@ -2,7 +2,6 @@ package edonymyeon.backend.thumbs.application;
 
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_ID_NOT_FOUND;
 import static edonymyeon.backend.global.exception.ExceptionInformation.THUMBS_POST_IS_LOGIN_MEMBER;
-import static edonymyeon.backend.global.exception.ExceptionInformation.THUMBS_UP_ALREADY_EXIST;
 
 import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.member.application.dto.MemberIdDto;
@@ -51,11 +50,6 @@ public class ThumbsService {
         }
 
         Thumbs thumbs = postThumbs.get();
-
-        if (thumbs.isUp()) {
-            throw new EdonymyeonException(THUMBS_UP_ALREADY_EXIST);
-        }
-
-        thumbs.updateThumbsType();
+        thumbs.up();
     }
 }

--- a/backend/src/main/java/edonymyeon/backend/thumbs/application/ThumbsService.java
+++ b/backend/src/main/java/edonymyeon/backend/thumbs/application/ThumbsService.java
@@ -16,9 +16,11 @@ import edonymyeon.backend.thumbs.repository.ThumbsRepository;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-@Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
 public class ThumbsService {
 
     private final ThumbsRepository thumbsRepository;
@@ -27,6 +29,7 @@ public class ThumbsService {
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
 
+    @Transactional
     public void thumbsUp(final MemberIdDto memberId, final Long postId) {
         Member loginMember = memberRepository.findById(memberId.id())
                 .orElseThrow(() -> new EdonymyeonException(MEMBER_ID_NOT_FOUND));

--- a/backend/src/main/java/edonymyeon/backend/thumbs/domain/Thumbs.java
+++ b/backend/src/main/java/edonymyeon/backend/thumbs/domain/Thumbs.java
@@ -1,5 +1,8 @@
 package edonymyeon.backend.thumbs.domain;
 
+import static edonymyeon.backend.global.exception.ExceptionInformation.THUMBS_UP_ALREADY_EXIST;
+
+import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.post.domain.Post;
 import jakarta.persistence.Entity;
@@ -42,11 +45,18 @@ public class Thumbs {
         this.thumbsType = thumbsType;
     }
 
-    public boolean isUp() {
+    private boolean isUp() {
         return thumbsType == ThumbsType.UP;
     }
 
-    public void updateThumbsType() {
+    private void updateThumbsType() {
         this.thumbsType = thumbsType.getReverseType();
+    }
+
+    public void up() {
+        if(isUp()){
+            throw new EdonymyeonException(THUMBS_UP_ALREADY_EXIST);
+        }
+        updateThumbsType();
     }
 }

--- a/backend/src/main/java/edonymyeon/backend/thumbs/domain/Thumbs.java
+++ b/backend/src/main/java/edonymyeon/backend/thumbs/domain/Thumbs.java
@@ -39,7 +39,11 @@ public class Thumbs {
     @Enumerated(value = EnumType.STRING)
     private ThumbsType thumbsType;
 
-    public Thumbs(final Post post, final Member member, final ThumbsType thumbsType) {
+    public Thumbs(
+            final Post post,
+            final Member member,
+            final ThumbsType thumbsType
+    ) {
         this.post = post;
         this.member = member;
         this.thumbsType = thumbsType;

--- a/backend/src/main/java/edonymyeon/backend/thumbs/domain/Thumbs.java
+++ b/backend/src/main/java/edonymyeon/backend/thumbs/domain/Thumbs.java
@@ -14,7 +14,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,7 +27,7 @@ public class Thumbs {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn
     private Post post;
 
@@ -58,7 +57,7 @@ public class Thumbs {
     }
 
     public void up() {
-        if(isUp()){
+        if (isUp()) {
             throw new EdonymyeonException(THUMBS_UP_ALREADY_EXIST);
         }
         updateThumbsType();

--- a/backend/src/main/java/edonymyeon/backend/thumbs/domain/Thumbs.java
+++ b/backend/src/main/java/edonymyeon/backend/thumbs/domain/Thumbs.java
@@ -1,0 +1,52 @@
+package edonymyeon.backend.thumbs.domain;
+
+import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.post.domain.Post;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Thumbs {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn
+    private Member member;
+
+    @Enumerated(value = EnumType.STRING)
+    private ThumbsType thumbsType;
+
+    public Thumbs(final Post post, final Member member, final ThumbsType thumbsType) {
+        this.post = post;
+        this.member = member;
+        this.thumbsType = thumbsType;
+    }
+
+    public boolean isUp() {
+        return thumbsType == ThumbsType.UP;
+    }
+
+    public void updateThumbsType() {
+        this.thumbsType = thumbsType.getReverseType();
+    }
+}

--- a/backend/src/main/java/edonymyeon/backend/thumbs/domain/ThumbsType.java
+++ b/backend/src/main/java/edonymyeon/backend/thumbs/domain/ThumbsType.java
@@ -1,0 +1,13 @@
+package edonymyeon.backend.thumbs.domain;
+
+public enum ThumbsType {
+
+    UP, DOWN;
+
+    public ThumbsType getReverseType() {
+        if(this == ThumbsType.UP){
+            return ThumbsType.DOWN;
+        }
+        return ThumbsType.UP;
+    }
+}

--- a/backend/src/main/java/edonymyeon/backend/thumbs/repository/ThumbsRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/thumbs/repository/ThumbsRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ThumbsRepository extends JpaRepository<Thumbs, Long> {
 
-    Optional<Thumbs> findByPostIdAndMemberId(Long postId, Long memberId);
+    Optional<Thumbs> findByPostIdAndMemberId(final Long postId, final Long memberId);
 }

--- a/backend/src/main/java/edonymyeon/backend/thumbs/repository/ThumbsRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/thumbs/repository/ThumbsRepository.java
@@ -1,0 +1,10 @@
+package edonymyeon.backend.thumbs.repository;
+
+import edonymyeon.backend.thumbs.domain.Thumbs;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ThumbsRepository extends JpaRepository<Thumbs, Long> {
+
+    Optional<Thumbs> findByPostIdAndMemberId(Long postId, Long memberId);
+}

--- a/backend/src/main/java/edonymyeon/backend/thumbs/ui/ThumbsController.java
+++ b/backend/src/main/java/edonymyeon/backend/thumbs/ui/ThumbsController.java
@@ -1,0 +1,25 @@
+package edonymyeon.backend.thumbs.ui;
+
+import edonymyeon.backend.auth.annotation.AuthPrincipal;
+import edonymyeon.backend.member.application.dto.MemberIdDto;
+import edonymyeon.backend.thumbs.application.ThumbsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ThumbsController {
+
+    private final ThumbsService thumbsService;
+
+    @PutMapping("posts/{postId}/up")
+    public ResponseEntity<Void> thumbsUp(@AuthPrincipal final MemberIdDto memberId,
+                                         @PathVariable final Long postId){
+        thumbsService.thumbsUp(memberId, postId);
+        return ResponseEntity.ok()
+                .build();
+    }
+}

--- a/backend/src/test/java/edonymyeon/backend/thumbs/application/ThumbsServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/thumbs/application/ThumbsServiceTest.java
@@ -23,11 +23,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.test.context.TestConstructor.AutowireMode;
+import org.springframework.transaction.annotation.Transactional;
 
 @SuppressWarnings("NonAsciiCharacters")
 @RequiredArgsConstructor
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
+@Transactional
 @SpringBootTest
 class ThumbsServiceTest {
 

--- a/backend/src/test/java/edonymyeon/backend/thumbs/application/ThumbsServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/thumbs/application/ThumbsServiceTest.java
@@ -1,0 +1,145 @@
+package edonymyeon.backend.thumbs.application;
+
+import static edonymyeon.backend.global.exception.ExceptionInformation.THUMBS_UP_ALREADY_EXIST;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import edonymyeon.backend.global.exception.EdonymyeonException;
+import edonymyeon.backend.member.application.dto.MemberIdDto;
+import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.repository.MemberRepository;
+import edonymyeon.backend.post.application.PostService;
+import edonymyeon.backend.post.application.dto.PostRequest;
+import edonymyeon.backend.post.application.dto.PostResponse;
+import edonymyeon.backend.thumbs.domain.Thumbs;
+import edonymyeon.backend.thumbs.domain.ThumbsType;
+import edonymyeon.backend.thumbs.repository.ThumbsRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.TestConstructor.AutowireMode;
+
+@SuppressWarnings("NonAsciiCharacters")
+@RequiredArgsConstructor
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@TestConstructor(autowireMode = AutowireMode.ALL)
+@SpringBootTest
+class ThumbsServiceTest {
+
+    private final ThumbsService thumbsService;
+
+    private final MemberRepository memberRepository;
+
+    private final ThumbsRepository thumbsRepository;
+
+    private final PostService postService;
+
+    private Member postWriter;
+
+    private PostResponse postResponse;
+
+    @BeforeEach
+    public void 회원가입과_게시글쓰기를_한다() {
+        postWriter = new Member(
+                null,
+                "email",
+                "password",
+                "nickname",
+                "introduction",
+                null
+        );
+        memberRepository.save(postWriter);
+
+        PostRequest postRequest = new PostRequest(
+                "title",
+                "content",
+                1000L,
+                null
+        );
+
+        MemberIdDto memberId = new MemberIdDto(postWriter.getId());
+        postResponse = postService.createPost(memberId, postRequest);
+    }
+
+    @Test
+    void 추천하려는_게시물이_없으면_예외가_발생한다() {
+        MemberIdDto loginMemberId = new MemberIdDto(postWriter.getId());
+
+        // TODO: 없는 게시글 조회 예외 종류 추가 해주기
+        assertThatThrownBy(
+                () -> thumbsService.thumbsUp(loginMemberId, 1000L))
+                .isExactlyInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 추천한_게시물이_로그인한_사람이_작성한_것이라면_예외가_발생한다() {
+        MemberIdDto loginMemberId = new MemberIdDto(postWriter.getId());
+
+        assertThatThrownBy(
+                () -> thumbsService.thumbsUp(loginMemberId, postResponse.id()))
+                .isExactlyInstanceOf(EdonymyeonException.class);
+    }
+
+    @Test
+    void 추천시_해당게시물에_추천한_적_없으면_추가한다() {
+        // given
+        Member otherMember = new Member(
+                null,
+                "email2",
+                "password2",
+                "nickname2",
+                "introduction2",
+                null
+        );
+        memberRepository.save(otherMember);
+
+        // when
+        MemberIdDto otherMemberId = new MemberIdDto(otherMember.getId());
+        thumbsService.thumbsUp(otherMemberId, postResponse.id());
+
+        Optional<Thumbs> postThumbs = thumbsRepository.findByPostIdAndMemberId(postResponse.id(),
+                otherMember.getId());
+
+        // then
+        assertSoftly(softly -> {
+                    softly.assertThat(postThumbs).isPresent();
+                    softly.assertThat(postThumbs.get().getThumbsType()).isEqualTo(ThumbsType.UP);
+                    softly.assertThat(postThumbs.get().getMember().getId()).isEqualTo(otherMember.getId());
+                    softly.assertThat(postThumbs.get().getPost().getId()).isEqualTo(postResponse.id());
+                }
+        );
+    }
+
+    @Test
+    void 추천시_해당게시물에_비추천한_적_있으면_추천으로_업데이트_된다() {
+        // TODO : 비추 구현시 구현
+    }
+
+    @Test
+    void 추천시_해당게시물에_추천한_적_있으면_예외가_발생한다() {
+        // given
+        Member otherMember = new Member(
+                null,
+                "email2",
+                "password2",
+                "nickname2",
+                "introduction2",
+                null
+        );
+        memberRepository.save(otherMember);
+
+        // when
+        MemberIdDto otherMemberId = new MemberIdDto(otherMember.getId());
+        thumbsService.thumbsUp(otherMemberId, postResponse.id());
+
+        assertThatThrownBy(
+                () -> thumbsService.thumbsUp(otherMemberId, postResponse.id()))
+                .isExactlyInstanceOf(EdonymyeonException.class)
+                .hasMessage(THUMBS_UP_ALREADY_EXIST.getMessage());
+    }
+}

--- a/backend/src/test/java/edonymyeon/backend/thumbs/integration/ThumbsUpIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/thumbs/integration/ThumbsUpIntegrationTest.java
@@ -18,14 +18,14 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.DirtiesContext.MethodMode;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.test.context.TestConstructor.AutowireMode;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
-@DirtiesContext(methodMode = MethodMode.AFTER_METHOD)
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class ThumbsUpIntegrationTest {
 

--- a/backend/src/test/java/edonymyeon/backend/thumbs/integration/ThumbsUpIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/thumbs/integration/ThumbsUpIntegrationTest.java
@@ -17,12 +17,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.MethodMode;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.test.context.TestConstructor.AutowireMode;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @TestConstructor(autowireMode = AutowireMode.ALL)
+@DirtiesContext(methodMode = MethodMode.AFTER_METHOD)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class ThumbsUpIntegrationTest {
 

--- a/backend/src/test/java/edonymyeon/backend/thumbs/integration/ThumbsUpIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/thumbs/integration/ThumbsUpIntegrationTest.java
@@ -1,0 +1,96 @@
+package edonymyeon.backend.thumbs.integration;
+
+import static io.restassured.RestAssured.given;
+
+import edonymyeon.backend.member.application.dto.MemberIdDto;
+import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.repository.MemberRepository;
+import edonymyeon.backend.post.application.PostService;
+import edonymyeon.backend.post.application.dto.PostRequest;
+import edonymyeon.backend.post.application.dto.PostResponse;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.TestConstructor.AutowireMode;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@TestConstructor(autowireMode = AutowireMode.ALL)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class ThumbsUpIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    private final PostService postService;
+
+    private final MemberRepository memberRepository;
+
+    private Member postWriter;
+
+    public ThumbsUpIntegrationTest(final PostService postService, final MemberRepository memberRepository) {
+        this.postService = postService;
+        this.memberRepository = memberRepository;
+    }
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @BeforeEach
+    void 테스트_실행전_게시글을_작성하는_사람을_추가한다() {
+        postWriter = new Member(
+                null,
+                "email",
+                "password",
+                "nickname",
+                "introduction",
+                null
+        );
+        memberRepository.save(postWriter);
+    }
+
+    @Test
+    void 게시글_추천기능_정상작동() {
+        PostRequest postRequest = new PostRequest("title", "content", 1000L, null);
+        PostResponse postResponse = postService.createPost(new MemberIdDto(postWriter.getId()), postRequest);
+
+        Member otherMember = new Member(
+                null,
+                "email2",
+                "password2",
+                "nickname2",
+                "introduction2",
+                null
+        );
+        memberRepository.save(otherMember);
+
+        given().log().all()
+                .auth().preemptive().basic(otherMember.getEmail(), otherMember.getPassword())
+                .when()
+                .put("posts/" + postResponse.id() + "/up")
+                .then()
+                .log().all()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 로그인_되어있지_않다면_추천기능을_사용할_수_없다() {
+        PostRequest postRequest = new PostRequest("title", "content", 1000L, null);
+        PostResponse postResponse = postService.createPost(new MemberIdDto(1L), postRequest);
+
+        given().log().all()
+                .when()
+                .put("posts/" + postResponse.id() + "/up")
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+}


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #13 

## 📝 작업 요약
게시글 추천 기능을 작성하고 테스트를 추가하였습니다.
현재 모든 테스트/ postman 요청 성공합니다.

## 🔎 작업 상세 설명
- 로그인 되어있을때에만 게시글 추천이 가능합니다.
- 아이디에 해당하는 게시글이 있을때에만 추천이 가능합니다.
- 해당 게시글이 다른 사람이 작성한 글일때만 추천이 가능합니다.

- 이전에 추천/ 비추천한 내역이 없을시 새롭게 추가됩니다.
- 이전에 비추천한 내역이 있을시 추천으로 변경됩니다.
- 이전에 추천한 내역이 있을시 오류가 발생합니다 (추천 취소는 다른 api로 진행됨)

## 🌟 리뷰 요구 사항
컨벤션에서 주요 로직을 도메인에서 처리하기로 했던것 같은데, 
추천 도메인 성격상 서비스에 때려 넣게 됩니다.....
좋은 수정 아이디어가 있다면 추천 부탁 드립니다 ㅎㅎ

컨벤션에서 주요 로직을 도메인에서 처리하기로 했던것 같은데, 
추천 도메인 성격상 서비스에 때려 넣게 됩니다.....
좋은 수정 아이디어가 있다면 추천 부탁 드립니다 ㅎㅎ

서비스 테스트에서 추천 서비스와 레포지토리를 동시에 필드에 두고 테스트 하는 방법도 괜찮나여??
해당 요청의 응답은 status만 필요하고, 서비스에서 사용자 id와 post id로 추천 1개를 읽어오는 일은 업을 것 같아서 일케 구현 햇읍니다...

첫 리뷰 요청 잘부탁드립니다 !!!!! 🐸 