### PR TITLE
fix: 추천/비추천 로직 오류 수정

### DIFF
--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/postdetail/PostDetailViewModel.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/postdetail/PostDetailViewModel.kt
@@ -35,7 +35,7 @@ class PostDetailViewModel : ViewModel() {
 
     fun updateUpRecommendation(isChecked: Boolean) {
         val oldRecommendation = _recommendation.value?.toDomain() ?: return
-        if (oldRecommendation.isUp == isChecked) return
+        if (oldRecommendation.isUp && isChecked) return
 
         if (isChecked) {
             if (oldRecommendation.isDown) {
@@ -60,12 +60,12 @@ class PostDetailViewModel : ViewModel() {
 
     fun updateDownRecommendation(isChecked: Boolean) {
         val oldRecommendation = _recommendation.value?.toDomain() ?: return
-        if (oldRecommendation.isDown == isChecked) return
+        if (oldRecommendation.isDown && isChecked) return
 
         if (isChecked) {
             if (oldRecommendation.isUp) {
                 _recommendation.value = oldRecommendation.copy(
-                    downCount = oldRecommendation.downCount.decrease(),
+                    downCount = oldRecommendation.downCount.increase(),
                     isUp = false,
                     isDown = true,
                 ).toUiModel()


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #64 

## 📝 작업 요약

발생한 오류(이슈 참조)를 수정하였습니다.

## 🔎 작업 상세 설명

#### 문제 상황

이슈에서 언급하였듯, `if (oldRecommendation.isUp == isChecked) return` 코드를 추가해두었고,
이로 인해 추천(비추천)으로 인하여 비추천(추천)이 변경되는 경우
updateUpRecommendation/updateDownRecommendation가 실행되지 않는 문제가 있었습니다.

#### 해결 방법

해당 체크박스를 직접 클릭한 경우를 제외하고 간접적으로 updateUpRecommendation이 호출되는 경우는
Up이 되어있는 상황에서 Down을 하고 싶을 때, Up이 해제되는 경우 뿐이라고 판단되어서
isUp과 isChecked 둘 다 true일 때만 return하도록 조건문을 수정했습니다.

## 🌟 리뷰 요구 사항

변경 부분이 많지 않아 오래 걸리지 않을 것 같습니다!
테스트 해보시고 혹시 놓친 오류 상황이 있는지나,
위에서 언급한 해결 방법이 적합한지를 중심으로 리뷰 남겨주시면 감사하겠습니다 🌸 