### PR TITLE
refactor: 닉네임 제한 20자까지로 수정

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
+++ b/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
@@ -26,7 +26,7 @@ public class Member {
 
     private static final int MAX_EMAIL_LENGTH = 30;
     private static final int MAX_PASSWORD_LENGTH = 30;
-    private static final int MAX_NICKNAME_LENGTH = 10;
+    private static final int MAX_NICKNAME_LENGTH = 20;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/test/java/edonymyeon/backend/member/domain/MemberTest.java
+++ b/backend/src/test/java/edonymyeon/backend/member/domain/MemberTest.java
@@ -39,9 +39,9 @@ class MemberTest {
     }
 
     @Test
-    public void 닉네임이_10자_초과이면_예외발생() {
+    public void 닉네임이_20자_초과이면_예외발생() {
         StringBuilder nickName = new StringBuilder();
-        for (int i = 0; i < 11; i++) {
+        for (int i = 0; i < 21; i++) {
             nickName.append(i);
         }
         final String invalidNickName = nickName.toString();


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #69 

## 📝 작업 요약

- 닉네임 제한을 20자 까지로 수정하였습니다.

