### PR TITLE
Fix/#76 게시글 작성시 사진 없는데 디렉터리에 파일 생성되는 버그 수정

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
@@ -67,7 +67,7 @@ public class PostService {
     }
 
     private boolean isDummy(final MultipartFile multipartFile) {
-        return "".equals(multipartFile.getName());
+        return multipartFile.isEmpty();
     }
 
     private List<ImageInfo> uploadImages(final PostRequest postRequest) {

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -47,7 +48,8 @@ public class PostService {
         );
         postRepository.save(post);
 
-        if (Objects.isNull(postRequest.images()) || postRequest.images().isEmpty()) {
+        if (Objects.isNull(postRequest.images()) || postRequest.images().isEmpty() || isDummy(
+                postRequest.images().get(0))) {
             return new PostResponse(post.getId());
         }
 
@@ -62,6 +64,10 @@ public class PostService {
     private Member findMemberById(final MemberIdDto memberIdDto) {
         return memberRepository.findById(memberIdDto.id())
                 .orElseThrow(() -> new EdonymyeonException(MEMBER_ID_NOT_FOUND));
+    }
+
+    private boolean isDummy(final MultipartFile multipartFile) {
+        return "".equals(multipartFile.getName());
     }
 
     private List<ImageInfo> uploadImages(final PostRequest postRequest) {


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #76 

## 📝 작업 요약

게시글 작성시 사진 없는데 디렉터리에 파일 생성되는 버그를 수정하였습니다.

## 🔎 작업 상세 설명

안드로이드쪽에 확인을 해보니, 게시글 작성 요청이 들어올때 이미지가 있든 없든 images 필드가 꼭 들어와야하는데, 포스트맨에서 images 필드를 선택하고 아무런 이미지를 첨부하지 않으니, 저희의 PostService에 있는 images null확인 및 isEmpty() 검증 로직에 걸리지 않는 것을 발견하였습니다.
images.get(0).isEmpty()까지 체크를 해야 비어있는 멀티파일 리스트임을 확인 가능해서 해당 방향으로 수정하였습니다.

## 🌟 리뷰 요구 사항

> ㅜㅜ
