### PR TITLE
fix: 작성자의 프로필 사진이 없더라도 NPE가 발생하지 않도록 버그 수정

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
@@ -222,6 +222,13 @@ public class PostService {
     }
 
     private WriterDetailResponse getWriterResponse(final Member member) {
+        if (Objects.isNull(member.getProfileImageInfo())) {
+            return new WriterDetailResponse(
+                    member.getId(),
+                    member.getNickname(),
+                    null
+            );
+        }
         return new WriterDetailResponse(
                 member.getId(),
                 member.getNickname(),

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
@@ -21,8 +21,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.UUID;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -305,5 +307,18 @@ class PostServiceTest {
                 );
             }
         }
+    }
+
+    @Test
+    void 작성자의_프로필_사진이_없더라도_상세조회가_가능하다() throws IOException {
+        final Member member = new Member("anonymous@gmail.com", "password", "엘렐레", null);
+        memberRepository.save(member);
+
+        final MemberIdDto memberIdDto = new MemberIdDto(member.getId());
+        final PostResponse postResponse = postService.createPost(memberIdDto, getPostRequest());
+
+        Assertions
+                .assertThatCode(() -> postService.findSpecificPost(postResponse.id(), memberIdDto))
+                .doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #96 

## 📝 작업 요약

작성자의 프로필 사진이 없더라도 NPE가 발생하지 않도록 버그를 수정했습니다.