### PR TITLE
fix: 게시글과 추천의 연관관계 때문에 게시글이 삭제가 되지 않는 오류 수정

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
@@ -108,6 +108,7 @@ public class PostService {
         checkWriter(member, post);
 
         final List<ImageInfo> imageInfos = findImageInfosFromPost(post);
+        thumbsService.deleteAllThumbsInPost(postId);
         postImageInfoRepository.deleteAllByPostId(postId);
         postRepository.deleteById(postId);
         imageInfos.forEach(imageFileUploader::removeFile);

--- a/backend/src/main/java/edonymyeon/backend/thumbs/application/ThumbsService.java
+++ b/backend/src/main/java/edonymyeon/backend/thumbs/application/ThumbsService.java
@@ -109,6 +109,11 @@ public class ThumbsService {
     }
 
     @Transactional
+    public void deleteAllThumbsInPost(final Long postId) {
+        thumbsRepository.deleteAllByPostId(postId);
+    }
+
+    @Transactional
     public void deleteThumbsUp(final MemberIdDto memberId, final Long postId) {
         Member loginMember = findMemberById(memberId);
         Post post = findPostById(postId);

--- a/backend/src/main/java/edonymyeon/backend/thumbs/repository/ThumbsRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/thumbs/repository/ThumbsRepository.java
@@ -9,5 +9,7 @@ public interface ThumbsRepository extends JpaRepository<Thumbs, Long> {
 
     Optional<Thumbs> findByPostIdAndMemberId(final Long postId, final Long memberId);
 
-    List<Thumbs> findByPostId(Long postId);
+    List<Thumbs> findByPostId(final Long postId);
+
+    void deleteAllByPostId(final Long postId);
 }


### PR DESCRIPTION
## 📝 작업 요약
게시글과 추천의 연관관계 때문에 게시글이 삭제가 되지 않는 오류 수정