### PR TITLE
Feat/#106 게시글 작성, 수정할 때 개수 제한 및 테스트 후 이미지 삭제 기능 구현

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/global/exception/ExceptionInformation.java
+++ b/backend/src/main/java/edonymyeon/backend/global/exception/ExceptionInformation.java
@@ -19,6 +19,7 @@ public enum ExceptionInformation {
     POST_PRICE_ILLEGAL_SIZE(2543, "가격은 0원 이상 100억 이하여야 합니다."),
     POST_MEMBER_EMPTY(2544, "게시글에는 작성자가 있어야 합니다."),
     POST_MEMBER_FORBIDDEN(2666, "게시글 작성자만 게시글을 수정/삭제할 수 있습니다."),
+    POST_IMAGE_NUMBER_INVALID(2667, "게시글 하나에 이미지는 최대 10개까지 등록 가능합니다."),
 
     // 3___: 회원 관련
     MEMBER_ID_NOT_FOUND(3000, "존재하지 않는 회원입니다."),

--- a/backend/src/main/java/edonymyeon/backend/global/exception/ExceptionInformation.java
+++ b/backend/src/main/java/edonymyeon/backend/global/exception/ExceptionInformation.java
@@ -19,7 +19,7 @@ public enum ExceptionInformation {
     POST_PRICE_ILLEGAL_SIZE(2543, "가격은 0원 이상 100억 이하여야 합니다."),
     POST_MEMBER_EMPTY(2544, "게시글에는 작성자가 있어야 합니다."),
     POST_MEMBER_FORBIDDEN(2666, "게시글 작성자만 게시글을 수정/삭제할 수 있습니다."),
-    POST_IMAGE_NUMBER_INVALID(2667, "게시글 하나에 이미지는 최대 10개까지 등록 가능합니다."),
+    POST_IMAGE_COUNT_INVALID(2667, "게시글 하나에 이미지는 최대 10개까지 등록 가능합니다."),
 
     // 3___: 회원 관련
     MEMBER_ID_NOT_FOUND(3000, "존재하지 않는 회원입니다."),

--- a/backend/src/main/java/edonymyeon/backend/image/ImageFileUploader.java
+++ b/backend/src/main/java/edonymyeon/backend/image/ImageFileUploader.java
@@ -8,6 +8,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -37,6 +39,12 @@ public class ImageFileUploader {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public List<ImageInfo> uploadFiles(final List<MultipartFile> multipartFiles) {
+        return multipartFiles.stream()
+                .map(this::uploadFile)
+                .collect(Collectors.toList());
     }
 
     public String getFullPath(String storeName) {

--- a/backend/src/main/java/edonymyeon/backend/image/postimage/domain/PostImageInfos.java
+++ b/backend/src/main/java/edonymyeon/backend/image/postimage/domain/PostImageInfos.java
@@ -1,0 +1,23 @@
+package edonymyeon.backend.image.postimage.domain;
+
+import edonymyeon.backend.image.domain.ImageInfo;
+import edonymyeon.backend.post.domain.Post;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class PostImageInfos {
+
+    private final List<PostImageInfo> postImageInfos;
+
+    public PostImageInfos(final List<PostImageInfo> postImageInfos) {
+        this.postImageInfos = postImageInfos;
+    }
+
+    public static PostImageInfos of(final Post post, final List<ImageInfo> imageInfos) {
+        final List<PostImageInfo> postImageInfos = imageInfos.stream()
+                .map(imageInfo -> PostImageInfo.of(imageInfo, post))
+                .toList();
+        return new PostImageInfos(postImageInfos);
+    }
+}

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
@@ -2,7 +2,7 @@ package edonymyeon.backend.post.application;
 
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_ID_NOT_FOUND;
 import static edonymyeon.backend.global.exception.ExceptionInformation.POST_ID_NOT_FOUND;
-import static edonymyeon.backend.global.exception.ExceptionInformation.POST_IMAGE_NUMBER_INVALID;
+import static edonymyeon.backend.global.exception.ExceptionInformation.POST_IMAGE_COUNT_INVALID;
 import static edonymyeon.backend.global.exception.ExceptionInformation.POST_MEMBER_FORBIDDEN;
 
 import edonymyeon.backend.global.exception.EdonymyeonException;
@@ -71,8 +71,8 @@ public class PostService {
             return new PostResponse(post.getId());
         }
 
-        if (!post.isValidImageNumber(postRequest.images().size())) {
-            throw new EdonymyeonException(POST_IMAGE_NUMBER_INVALID);
+        if (!post.isValidImageCount(postRequest.images().size())) {
+            throw new EdonymyeonException(POST_IMAGE_COUNT_INVALID);
         }
 
         final List<PostImageInfo> postImageInfos = uploadImages(postRequest).stream()
@@ -159,8 +159,8 @@ public class PostService {
             return new PostResponse(postId);
         }
 
-        if (!post.isValidImageNumber(postRequest.images().size())) {
-            throw new EdonymyeonException(POST_IMAGE_NUMBER_INVALID);
+        if (!post.isValidImageCount(postRequest.images().size())) {
+            throw new EdonymyeonException(POST_IMAGE_COUNT_INVALID);
         }
         updateImagesOfPost(postRequest, post, originalImageInfos);
         return new PostResponse(postId);

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
@@ -8,6 +8,7 @@ import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.image.ImageFileUploader;
 import edonymyeon.backend.image.domain.Domain;
 import edonymyeon.backend.image.postimage.domain.PostImageInfo;
+import edonymyeon.backend.image.postimage.domain.PostImageInfos;
 import edonymyeon.backend.image.postimage.repository.PostImageInfoRepository;
 import edonymyeon.backend.member.application.dto.MemberIdDto;
 import edonymyeon.backend.member.domain.Member;
@@ -70,12 +71,10 @@ public class PostService {
         }
         post.checkImageCount(postRequest.images().size());
 
-        final List<PostImageInfo> postImageInfos = imageFileUploader.uploadFiles(postRequest.images())
-                .stream()
-                .map(imageInfo -> PostImageInfo.of(imageInfo, post))
-                .toList();
-        post.updateImages(postImageInfos);
-        postImageInfoRepository.saveAll(postImageInfos);
+        final PostImageInfos postImageInfos = PostImageInfos.of(post,
+                imageFileUploader.uploadFiles(postRequest.images()));
+        post.updateImages(postImageInfos.getPostImageInfos());
+        postImageInfoRepository.saveAll(postImageInfos.getPostImageInfos());
 
         return new PostResponse(post.getId());
     }
@@ -151,12 +150,10 @@ public class PostService {
             final Post post,
             final List<PostImageInfo> originalImageInfos
     ) {
-        final List<PostImageInfo> updatePostImageInfos = imageFileUploader.uploadFiles(postRequest.images())
-                .stream()
-                .map(imageInfo -> PostImageInfo.of(imageInfo, post))
-                .toList();
-        post.updateImages(updatePostImageInfos);
-        postImageInfoRepository.saveAll(updatePostImageInfos);
+        final PostImageInfos updatedPostImageInfos = PostImageInfos.of(post,
+                imageFileUploader.uploadFiles(postRequest.images()));
+        post.updateImages(updatedPostImageInfos.getPostImageInfos());
+        postImageInfoRepository.saveAll(updatedPostImageInfos.getPostImageInfos());
         originalImageInfos.forEach(imageFileUploader::removeFile);
     }
 

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
@@ -71,7 +71,7 @@ public class PostService {
             return new PostResponse(post.getId());
         }
 
-        if (!post.isValidImageCount(postRequest.images().size())) {
+        if (post.isInvalidImageCount(postRequest.images().size())) {
             throw new EdonymyeonException(POST_IMAGE_COUNT_INVALID);
         }
 
@@ -159,7 +159,7 @@ public class PostService {
             return new PostResponse(postId);
         }
 
-        if (!post.isValidImageCount(postRequest.images().size())) {
+        if (post.isInvalidImageCount(postRequest.images().size())) {
             throw new EdonymyeonException(POST_IMAGE_COUNT_INVALID);
         }
         updateImagesOfPost(postRequest, post, originalImageInfos);

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
@@ -7,7 +7,6 @@ import static edonymyeon.backend.global.exception.ExceptionInformation.POST_MEMB
 import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.image.ImageFileUploader;
 import edonymyeon.backend.image.domain.Domain;
-import edonymyeon.backend.image.domain.ImageInfo;
 import edonymyeon.backend.image.postimage.domain.PostImageInfo;
 import edonymyeon.backend.image.postimage.repository.PostImageInfoRepository;
 import edonymyeon.backend.member.application.dto.MemberIdDto;
@@ -103,7 +102,7 @@ public class PostService {
         final Post post = findPostById(postId);
         checkWriter(member, post);
 
-        final List<ImageInfo> imageInfos = findImageInfosFromPost(post);
+        final List<PostImageInfo> imageInfos = post.getPostImageInfos();
         thumbsService.deleteAllThumbsInPost(postId);
         postImageInfoRepository.deleteAllByPostId(postId);
         postRepository.deleteById(postId);
@@ -113,13 +112,6 @@ public class PostService {
     private Post findPostById(final Long postId) {
         return postRepository.findById(postId)
                 .orElseThrow(() -> new EdonymyeonException(POST_ID_NOT_FOUND));
-    }
-
-    private List<ImageInfo> findImageInfosFromPost(final Post post) {
-        return post.getPostImageInfos()
-                .stream()
-                .map(postImage -> new ImageInfo(postImage.getStoreName()))
-                .toList();
     }
 
     private void checkWriter(final Member member, final Post post) {
@@ -140,7 +132,7 @@ public class PostService {
 
         post.update(postRequest.title(), postRequest.content(), postRequest.price());
 
-        final List<ImageInfo> originalImageInfos = findImageInfosFromPost(post);
+        final List<PostImageInfo> originalImageInfos = post.getPostImageInfos();
         postImageInfoRepository.deleteAllByPostId(postId);
 
         if (isImagesEmpty(postRequest)) {
@@ -157,7 +149,7 @@ public class PostService {
     private void updateImagesOfPost(
             final PostRequest postRequest,
             final Post post,
-            final List<ImageInfo> originalImageInfos
+            final List<PostImageInfo> originalImageInfos
     ) {
         final List<PostImageInfo> updatePostImageInfos = imageFileUploader.uploadFiles(postRequest.images())
                 .stream()

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
@@ -71,7 +71,8 @@ public class PostService {
         }
         post.checkImageCount(postRequest.images().size());
 
-        final List<PostImageInfo> postImageInfos = uploadImages(postRequest).stream()
+        final List<PostImageInfo> postImageInfos = imageFileUploader.uploadFiles(postRequest.images())
+                .stream()
                 .map(imageInfo -> PostImageInfo.of(imageInfo, post))
                 .toList();
         post.updateImages(postImageInfos);
@@ -94,13 +95,6 @@ public class PostService {
 
     private boolean isDummy(final MultipartFile multipartFile) {
         return multipartFile.isEmpty();
-    }
-
-    private List<ImageInfo> uploadImages(final PostRequest postRequest) {
-        return postRequest.images()
-                .stream()
-                .map(imageFileUploader::uploadFile)
-                .toList();
     }
 
     @Transactional
@@ -165,7 +159,8 @@ public class PostService {
             final Post post,
             final List<ImageInfo> originalImageInfos
     ) {
-        final List<PostImageInfo> updatePostImageInfos = uploadImages(postRequest).stream()
+        final List<PostImageInfo> updatePostImageInfos = imageFileUploader.uploadFiles(postRequest.images())
+                .stream()
                 .map(imageInfo -> PostImageInfo.of(imageInfo, post))
                 .toList();
         post.updateImages(updatePostImageInfos);

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
@@ -2,6 +2,7 @@ package edonymyeon.backend.post.application;
 
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_ID_NOT_FOUND;
 import static edonymyeon.backend.global.exception.ExceptionInformation.POST_ID_NOT_FOUND;
+import static edonymyeon.backend.global.exception.ExceptionInformation.POST_IMAGE_NUMBER_INVALID;
 import static edonymyeon.backend.global.exception.ExceptionInformation.POST_MEMBER_FORBIDDEN;
 
 import edonymyeon.backend.global.exception.EdonymyeonException;
@@ -70,9 +71,14 @@ public class PostService {
             return new PostResponse(post.getId());
         }
 
+        if (!post.isValidImageNumber(postRequest.images().size())) {
+            throw new EdonymyeonException(POST_IMAGE_NUMBER_INVALID);
+        }
+
         final List<PostImageInfo> postImageInfos = uploadImages(postRequest).stream()
                 .map(imageInfo -> PostImageInfo.of(imageInfo, post))
                 .toList();
+        post.updateImages(postImageInfos);
         postImageInfoRepository.saveAll(postImageInfos);
 
         return new PostResponse(post.getId());
@@ -153,6 +159,9 @@ public class PostService {
             return new PostResponse(postId);
         }
 
+        if (!post.isValidImageNumber(postRequest.images().size())) {
+            throw new EdonymyeonException(POST_IMAGE_NUMBER_INVALID);
+        }
         updateImagesOfPost(postRequest, post, originalImageInfos);
         return new PostResponse(postId);
     }

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
@@ -2,7 +2,6 @@ package edonymyeon.backend.post.application;
 
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_ID_NOT_FOUND;
 import static edonymyeon.backend.global.exception.ExceptionInformation.POST_ID_NOT_FOUND;
-import static edonymyeon.backend.global.exception.ExceptionInformation.POST_IMAGE_COUNT_INVALID;
 import static edonymyeon.backend.global.exception.ExceptionInformation.POST_MEMBER_FORBIDDEN;
 
 import edonymyeon.backend.global.exception.EdonymyeonException;
@@ -70,10 +69,7 @@ public class PostService {
         if (isImagesEmpty(postRequest)) {
             return new PostResponse(post.getId());
         }
-
-        if (post.isInvalidImageCount(postRequest.images().size())) {
-            throw new EdonymyeonException(POST_IMAGE_COUNT_INVALID);
-        }
+        post.checkImageCount(postRequest.images().size());
 
         final List<PostImageInfo> postImageInfos = uploadImages(postRequest).stream()
                 .map(imageInfo -> PostImageInfo.of(imageInfo, post))
@@ -159,9 +155,7 @@ public class PostService {
             return new PostResponse(postId);
         }
 
-        if (post.isInvalidImageCount(postRequest.images().size())) {
-            throw new EdonymyeonException(POST_IMAGE_COUNT_INVALID);
-        }
+        post.checkImageCount(postRequest.images().size());
         updateImagesOfPost(postRequest, post, originalImageInfos);
         return new PostResponse(postId);
     }

--- a/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
+++ b/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
@@ -128,17 +128,17 @@ public class Post {
         if (this.postImageInfos.contains(postImageInfo)) {
             return;
         }
-        checkImageCount(this.postImageInfos);
+        checkImageCount(this.postImageInfos.size());
         this.postImageInfos.add(postImageInfo);
     }
 
-    private void checkImageCount(final List<PostImageInfo> postImageInfos) {
+    public void checkImageCount(final Integer imageCount) {
         if (isInvalidImageCount(postImageInfos.size())) {
             throw new EdonymyeonException(POST_IMAGE_COUNT_INVALID);
         }
     }
 
-    public boolean isInvalidImageCount(final Integer imageCount) {
+    private boolean isInvalidImageCount(final Integer imageCount) {
         return imageCount > MAX_IMAGE_COUNT;
     }
 
@@ -164,7 +164,7 @@ public class Post {
     }
 
     public void updateImages(final List<PostImageInfo> postImageInfos) {
-        checkImageCount(postImageInfos);
+        checkImageCount(postImageInfos.size());
         this.postImageInfos.clear();
         this.postImageInfos.addAll(postImageInfos);
     }

--- a/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
+++ b/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
@@ -133,13 +133,13 @@ public class Post {
     }
 
     private void checkImageCount(final List<PostImageInfo> postImageInfos) {
-        if (!isValidImageCount(postImageInfos.size())) {
+        if (isInvalidImageCount(postImageInfos.size())) {
             throw new EdonymyeonException(POST_IMAGE_COUNT_INVALID);
         }
     }
 
-    public boolean isValidImageCount(final Integer imageCount) {
-        return imageCount >= MIN_IMAGE_COUNT && imageCount < MAX_IMAGE_COUNT;
+    public boolean isInvalidImageCount(final Integer imageCount) {
+        return imageCount > MAX_IMAGE_COUNT;
     }
 
     public void update(final String title, final String content, final Long price) {

--- a/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
+++ b/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
@@ -1,6 +1,7 @@
 package edonymyeon.backend.post.domain;
 
 import static edonymyeon.backend.global.exception.ExceptionInformation.POST_CONTENT_ILLEGAL_LENGTH;
+import static edonymyeon.backend.global.exception.ExceptionInformation.POST_IMAGE_NUMBER_INVALID;
 import static edonymyeon.backend.global.exception.ExceptionInformation.POST_MEMBER_EMPTY;
 import static edonymyeon.backend.global.exception.ExceptionInformation.POST_PRICE_ILLEGAL_SIZE;
 import static edonymyeon.backend.global.exception.ExceptionInformation.POST_TITLE_ILLEGAL_LENGTH;
@@ -41,6 +42,8 @@ public class Post {
     private static final int MAX_CONTENT_LENGTH = 1_000;
     private static final long MAX_PRICE = 10_000_000_000L;
     private static final int MIN_PRICE = 0;
+    public static final int MAX_IMAGE_NUMBER = 10;
+    public static final int MIN_IMAGE_NUMBER = 0;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -125,7 +128,18 @@ public class Post {
         if (this.postImageInfos.contains(postImageInfo)) {
             return;
         }
+        checkImageNumber(this.postImageInfos);
         this.postImageInfos.add(postImageInfo);
+    }
+
+    private void checkImageNumber(final List<PostImageInfo> postImageInfos) {
+        if (!isValidImageNumber(postImageInfos.size())) {
+            throw new EdonymyeonException(POST_IMAGE_NUMBER_INVALID);
+        }
+    }
+
+    public boolean isValidImageNumber(final Integer imageNumber) {
+        return imageNumber >= MIN_IMAGE_NUMBER && imageNumber < MAX_IMAGE_NUMBER;
     }
 
     public void update(final String title, final String content, final Long price) {
@@ -150,6 +164,7 @@ public class Post {
     }
 
     public void updateImages(final List<PostImageInfo> postImageInfos) {
+        checkImageNumber(postImageInfos);
         this.postImageInfos.clear();
         this.postImageInfos.addAll(postImageInfos);
     }

--- a/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
+++ b/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
@@ -1,7 +1,7 @@
 package edonymyeon.backend.post.domain;
 
 import static edonymyeon.backend.global.exception.ExceptionInformation.POST_CONTENT_ILLEGAL_LENGTH;
-import static edonymyeon.backend.global.exception.ExceptionInformation.POST_IMAGE_NUMBER_INVALID;
+import static edonymyeon.backend.global.exception.ExceptionInformation.POST_IMAGE_COUNT_INVALID;
 import static edonymyeon.backend.global.exception.ExceptionInformation.POST_MEMBER_EMPTY;
 import static edonymyeon.backend.global.exception.ExceptionInformation.POST_PRICE_ILLEGAL_SIZE;
 import static edonymyeon.backend.global.exception.ExceptionInformation.POST_TITLE_ILLEGAL_LENGTH;
@@ -42,8 +42,8 @@ public class Post {
     private static final int MAX_CONTENT_LENGTH = 1_000;
     private static final long MAX_PRICE = 10_000_000_000L;
     private static final int MIN_PRICE = 0;
-    public static final int MAX_IMAGE_NUMBER = 10;
-    public static final int MIN_IMAGE_NUMBER = 0;
+    public static final int MAX_IMAGE_COUNT = 10;
+    public static final int MIN_IMAGE_COUNT = 0;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -128,18 +128,18 @@ public class Post {
         if (this.postImageInfos.contains(postImageInfo)) {
             return;
         }
-        checkImageNumber(this.postImageInfos);
+        checkImageCount(this.postImageInfos);
         this.postImageInfos.add(postImageInfo);
     }
 
-    private void checkImageNumber(final List<PostImageInfo> postImageInfos) {
-        if (!isValidImageNumber(postImageInfos.size())) {
-            throw new EdonymyeonException(POST_IMAGE_NUMBER_INVALID);
+    private void checkImageCount(final List<PostImageInfo> postImageInfos) {
+        if (!isValidImageCount(postImageInfos.size())) {
+            throw new EdonymyeonException(POST_IMAGE_COUNT_INVALID);
         }
     }
 
-    public boolean isValidImageNumber(final Integer imageNumber) {
-        return imageNumber >= MIN_IMAGE_NUMBER && imageNumber < MAX_IMAGE_NUMBER;
+    public boolean isValidImageCount(final Integer imageCount) {
+        return imageCount >= MIN_IMAGE_COUNT && imageCount < MAX_IMAGE_COUNT;
     }
 
     public void update(final String title, final String content, final Long price) {
@@ -164,7 +164,7 @@ public class Post {
     }
 
     public void updateImages(final List<PostImageInfo> postImageInfos) {
-        checkImageNumber(postImageInfos);
+        checkImageCount(postImageInfos);
         this.postImageInfos.clear();
         this.postImageInfos.addAll(postImageInfos);
     }

--- a/backend/src/test/java/edonymyeon/backend/post/ImageFileCleaner.java
+++ b/backend/src/test/java/edonymyeon/backend/post/ImageFileCleaner.java
@@ -1,0 +1,23 @@
+package edonymyeon.backend.post;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.Arrays;
+import org.junit.jupiter.api.AfterEach;
+
+public interface ImageFileCleaner {
+
+    @AfterEach
+    default void cleanImageStoreDirectory() {
+        final File targetFolder = new File("src/test/resources/static/img/test_store/");
+        FilenameFilter filter = new FilenameFilter() {
+            @Override
+            public boolean accept(final File dir, final String name) {
+                return !name.equals("test.txt");
+            }
+        };
+        File[] files = targetFolder.listFiles(filter);
+        assert files != null;
+        Arrays.stream(files).forEach(file -> file.delete());
+    }
+}

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostServiceFindingAllPostsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostServiceFindingAllPostsTest.java
@@ -8,19 +8,16 @@ import edonymyeon.backend.image.postimage.repository.PostImageInfoRepository;
 import edonymyeon.backend.member.application.dto.MemberIdDto;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.repository.MemberRepository;
+import edonymyeon.backend.post.ImageFileCleaner;
 import edonymyeon.backend.post.application.dto.GeneralFindingCondition;
 import edonymyeon.backend.post.application.dto.GeneralPostInfoResponse;
 import edonymyeon.backend.post.application.dto.PostRequest;
 import edonymyeon.backend.post.application.dto.PostResponse;
 import edonymyeon.backend.post.repository.PostRepository;
-import java.io.File;
-import java.io.FilenameFilter;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -46,7 +43,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Import(TestConfig.class)
 @TestInstance(Lifecycle.PER_CLASS)
 @DisplayName("게시글 전체 조회 테스트")
-public class PostServiceFindingAllPostsTest {
+public class PostServiceFindingAllPostsTest implements ImageFileCleaner {
 
     public static final String POST_REQUEST1_TITLE = "Lost in Time";
     public static final String POST_REQUEST1_CONTENT = "A young archaeologist discovers a mysterious artifact that transports her back in time, forcing her to navigate ancient civilizations and find a way back home before history unravels.";
@@ -233,19 +230,5 @@ public class PostServiceFindingAllPostsTest {
         );
 
         return postService.createPost(memberId, POST_REQUEST3);
-    }
-
-    @AfterEach
-    public void cleanImageStoreDirectory() {
-        final File targetFolder = new File("src/test/resources/static/img/test_store/");
-        FilenameFilter filter = new FilenameFilter() {
-            @Override
-            public boolean accept(final File dir, final String name) {
-                return !name.equals("test.txt");
-            }
-        };
-        File[] files = targetFolder.listFiles(filter);
-        assert files != null;
-        Arrays.stream(files).forEach(file -> file.delete());
     }
 }

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostServiceFindingAllPostsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostServiceFindingAllPostsTest.java
@@ -13,10 +13,14 @@ import edonymyeon.backend.post.application.dto.GeneralPostInfoResponse;
 import edonymyeon.backend.post.application.dto.PostRequest;
 import edonymyeon.backend.post.application.dto.PostResponse;
 import edonymyeon.backend.post.repository.PostRepository;
+import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -229,5 +233,19 @@ public class PostServiceFindingAllPostsTest {
         );
 
         return postService.createPost(memberId, POST_REQUEST3);
+    }
+
+    @AfterEach
+    public void cleanImageStoreDirectory() {
+        final File targetFolder = new File("src/test/resources/static/img/test_store/");
+        FilenameFilter filter = new FilenameFilter() {
+            @Override
+            public boolean accept(final File dir, final String name) {
+                return !name.equals("test.txt");
+            }
+        };
+        File[] files = targetFolder.listFiles(filter);
+        assert files != null;
+        Arrays.stream(files).forEach(file -> file.delete());
     }
 }

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
@@ -174,7 +174,7 @@ class PostServiceTest {
 
             // when
             assertThatThrownBy(() -> postService.createPost(memberId, request)).isInstanceOf(EdonymyeonException.class)
-                    .hasMessage(ExceptionInformation.POST_IMAGE_NUMBER_INVALID.getMessage());
+                    .hasMessage(ExceptionInformation.POST_IMAGE_COUNT_INVALID.getMessage());
         }
     }
 
@@ -293,7 +293,7 @@ class PostServiceTest {
                 );
                 assertThatThrownBy(() -> postService.updatePost(memberId, post.id(), request)).isInstanceOf(
                                 EdonymyeonException.class)
-                        .hasMessage(ExceptionInformation.POST_IMAGE_NUMBER_INVALID.getMessage());
+                        .hasMessage(ExceptionInformation.POST_IMAGE_COUNT_INVALID.getMessage());
             }
 
             @Test

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
@@ -13,22 +13,20 @@ import edonymyeon.backend.image.postimage.repository.PostImageInfoRepository;
 import edonymyeon.backend.member.application.dto.MemberIdDto;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.repository.MemberRepository;
+import edonymyeon.backend.post.ImageFileCleaner;
 import edonymyeon.backend.post.application.dto.PostRequest;
 import edonymyeon.backend.post.application.dto.PostResponse;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;
 import edonymyeon.backend.support.MemberTestSupport;
 import java.io.File;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -50,7 +48,7 @@ import org.springframework.web.multipart.MultipartFile;
 @TestConstructor(autowireMode = AutowireMode.ALL)
 @Import(TestConfig.class)
 @SpringBootTest
-class PostServiceTest {
+class PostServiceTest implements ImageFileCleaner {
 
     private static final Pattern 이미지_UUID_와_확장자_형식 = Pattern.compile("test-inserting\\d+\\.(png|jpg)");
     private static final Pattern 파일_경로_형식 = Pattern.compile(
@@ -352,7 +350,7 @@ class PostServiceTest {
                 final PostImageInfo 바꾼_후_이미지_정보 = findPost.getPostImageInfos().get(0);
 
                 assertSoftly(softly -> {
-                            softly.assertThat(findPost.getPostImageInfos().size()).isEqualTo(게시글_수정_요청.images().size());
+                    softly.assertThat(findPost.getPostImageInfos().size()).isEqualTo(게시글_수정_요청.images().size());
                     softly.assertThat(바꾸기_전_이미지_정보.getStoreName().equals(바꾼_후_이미지_정보.getStoreName())).isFalse();
                         }
                 );
@@ -371,19 +369,5 @@ class PostServiceTest {
         Assertions
                 .assertThatCode(() -> postService.findSpecificPost(postResponse.id(), memberIdDto))
                 .doesNotThrowAnyException();
-    }
-
-    @AfterEach
-    public void cleanImageStoreDirectory() {
-        final File targetFolder = new File("src/test/resources/static/img/test_store/");
-        FilenameFilter filter = new FilenameFilter() {
-            @Override
-            public boolean accept(final File dir, final String name) {
-                return !name.equals("test.txt");
-            }
-        };
-        File[] files = targetFolder.listFiles(filter);
-        assert files != null;
-        Arrays.stream(files).forEach(file -> file.delete());
     }
 }

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import edonymyeon.backend.TestConfig;
 import edonymyeon.backend.global.exception.EdonymyeonException;
+import edonymyeon.backend.global.exception.ExceptionInformation;
 import edonymyeon.backend.image.ImageFileUploader;
 import edonymyeon.backend.image.postimage.domain.PostImageInfo;
 import edonymyeon.backend.image.postimage.repository.PostImageInfoRepository;
@@ -20,6 +21,7 @@ import edonymyeon.backend.support.MemberTestSupport;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
@@ -151,6 +153,31 @@ class PostServiceTest {
                     }
             );
         }
+
+        @Test
+        void 이미지가_10개_초과일_수_없다()
+                throws IOException {
+            // given
+            List<MultipartFile> images = new ArrayList<>();
+            for (int i = 0; i < 11; i++) {
+                images.add(createMockMultipartFile());
+            }
+            final PostRequest request = new PostRequest(
+                    "사도 돼요?",
+                    "얼마 안해요",
+                    100_000L,
+                    images
+            );
+
+            // when
+            assertThatThrownBy(() -> postService.createPost(memberId, request)).isInstanceOf(EdonymyeonException.class)
+                    .hasMessage(ExceptionInformation.POST_IMAGE_NUMBER_INVALID.getMessage());
+        }
+    }
+
+    private MockMultipartFile createMockMultipartFile() throws IOException {
+        return new MockMultipartFile("imageFiles", "test_image_1.jpg", "image/jpg",
+                getClass().getResourceAsStream("/static/img/file/test_image_1.jpg"));
     }
 
     @Nested
@@ -242,6 +269,28 @@ class PostServiceTest {
             );
 
             이미지를_수정하는_경우() throws IOException {
+            }
+
+            @Test
+            void 이미지가_10개_초과일_수_없다()
+                    throws IOException {
+                // given
+                final PostResponse post = postService.createPost(memberId, 이미지가_없는_요청);
+
+                // when
+                List<MultipartFile> images = new ArrayList<>();
+                for (int i = 0; i < 11; i++) {
+                    images.add(createMockMultipartFile());
+                }
+                final PostRequest request = new PostRequest(
+                        "사도 돼요?",
+                        "얼마 안해요",
+                        100_000L,
+                        images
+                );
+                assertThatThrownBy(() -> postService.updatePost(memberId, post.id(), request)).isInstanceOf(
+                                EdonymyeonException.class)
+                        .hasMessage(ExceptionInformation.POST_IMAGE_NUMBER_INVALID.getMessage());
             }
 
             @Test

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
@@ -19,13 +19,16 @@ import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;
 import edonymyeon.backend.support.MemberTestSupport;
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -368,5 +371,19 @@ class PostServiceTest {
         Assertions
                 .assertThatCode(() -> postService.findSpecificPost(postResponse.id(), memberIdDto))
                 .doesNotThrowAnyException();
+    }
+
+    @AfterEach
+    public void cleanImageStoreDirectory() {
+        final File targetFolder = new File("src/test/resources/static/img/test_store/");
+        FilenameFilter filter = new FilenameFilter() {
+            @Override
+            public boolean accept(final File dir, final String name) {
+                return !name.equals("test.txt");
+            }
+        };
+        File[] files = targetFolder.listFiles(filter);
+        assert files != null;
+        Arrays.stream(files).forEach(file -> file.delete());
     }
 }

--- a/backend/src/test/java/edonymyeon/backend/post/integration/PostIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/integration/PostIntegrationTest.java
@@ -14,9 +14,12 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -325,5 +328,19 @@ public class PostIntegrationTest extends IntegrationTest {
                 13_000L,
                 multipartFiles
         );
+    }
+
+    @AfterEach
+    public void cleanImageStoreDirectory() {
+        final File targetFolder = new File("src/test/resources/static/img/test_store/");
+        FilenameFilter filter = new FilenameFilter() {
+            @Override
+            public boolean accept(final File dir, final String name) {
+                return !name.equals("test.txt");
+            }
+        };
+        File[] files = targetFolder.listFiles(filter);
+        assert files != null;
+        Arrays.stream(files).forEach(file -> file.delete());
     }
 }

--- a/backend/src/test/java/edonymyeon/backend/post/integration/PostIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/integration/PostIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import edonymyeon.backend.IntegrationTest;
 import edonymyeon.backend.member.application.dto.MemberIdDto;
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.post.ImageFileCleaner;
 import edonymyeon.backend.post.application.PostService;
 import edonymyeon.backend.post.application.dto.PostRequest;
 import edonymyeon.backend.post.application.dto.PostResponse;
@@ -14,12 +15,9 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.io.File;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,7 +28,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
 @SuppressWarnings("NonAsciiCharacters")
-public class PostIntegrationTest extends IntegrationTest {
+public class PostIntegrationTest extends IntegrationTest implements ImageFileCleaner {
 
     @LocalServerPort
     private int port;
@@ -328,19 +326,5 @@ public class PostIntegrationTest extends IntegrationTest {
                 13_000L,
                 multipartFiles
         );
-    }
-
-    @AfterEach
-    public void cleanImageStoreDirectory() {
-        final File targetFolder = new File("src/test/resources/static/img/test_store/");
-        FilenameFilter filter = new FilenameFilter() {
-            @Override
-            public boolean accept(final File dir, final String name) {
-                return !name.equals("test.txt");
-            }
-        };
-        File[] files = targetFolder.listFiles(filter);
-        assert files != null;
-        Arrays.stream(files).forEach(file -> file.delete());
     }
 }

--- a/backend/src/test/java/edonymyeon/backend/post/ui/PostControllerTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/ui/PostControllerTest.java
@@ -7,16 +7,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edonymyeon.backend.global.controlleradvice.dto.ExceptionResponse;
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.post.ImageFileCleaner;
 import edonymyeon.backend.post.application.dto.PostResponse;
 import edonymyeon.backend.support.MemberTestSupport;
-import java.io.File;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Base64;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -38,7 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SpringBootTest
 @AutoConfigureMockMvc
-class PostControllerTest {
+class PostControllerTest implements ImageFileCleaner {
 
     @Autowired
     MockMvc mockMvc;
@@ -181,7 +178,7 @@ class PostControllerTest {
         );
     }
 
-    @AfterEach
+/*    @AfterEach
     public void cleanImageStoreDirectory() {
         final File targetFolder = new File("src/test/resources/static/img/test_store/");
         FilenameFilter filter = new FilenameFilter() {
@@ -193,5 +190,5 @@ class PostControllerTest {
         File[] files = targetFolder.listFiles(filter);
         assert files != null;
         Arrays.stream(files).forEach(file -> file.delete());
-    }
+    }*/
 }

--- a/backend/src/test/java/edonymyeon/backend/post/ui/PostControllerTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/ui/PostControllerTest.java
@@ -177,18 +177,4 @@ class PostControllerTest implements ImageFileCleaner {
                 }
         );
     }
-
-/*    @AfterEach
-    public void cleanImageStoreDirectory() {
-        final File targetFolder = new File("src/test/resources/static/img/test_store/");
-        FilenameFilter filter = new FilenameFilter() {
-            @Override
-            public boolean accept(final File dir, final String name) {
-                return !name.equals("test.txt");
-            }
-        };
-        File[] files = targetFolder.listFiles(filter);
-        assert files != null;
-        Arrays.stream(files).forEach(file -> file.delete());
-    }*/
 }

--- a/backend/src/test/java/edonymyeon/backend/post/ui/PostControllerTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/ui/PostControllerTest.java
@@ -9,10 +9,14 @@ import edonymyeon.backend.global.controlleradvice.dto.ExceptionResponse;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.post.application.dto.PostResponse;
 import edonymyeon.backend.support.MemberTestSupport;
+import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Base64;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -175,5 +179,19 @@ class PostControllerTest {
                     softly.assertThat(예외_응답.errorCode()).isEqualTo(POST_MEMBER_FORBIDDEN.getCode());
                 }
         );
+    }
+
+    @AfterEach
+    public void cleanImageStoreDirectory() {
+        final File targetFolder = new File("src/test/resources/static/img/test_store/");
+        FilenameFilter filter = new FilenameFilter() {
+            @Override
+            public boolean accept(final File dir, final String name) {
+                return !name.equals("test.txt");
+            }
+        };
+        File[] files = targetFolder.listFiles(filter);
+        assert files != null;
+        Arrays.stream(files).forEach(file -> file.delete());
     }
 }


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #106 

## 📝 작업 요약

- 게시글 등록, 수정 시 이미지 10개 검증 로직을 추가
- 테스트할때 이미지가 생성되어 저장되는 테스트 클래스들에 `@AfterEach`로 테스트가 끝난 후 해당 디렉토리의 이미지 파일들을 삭제하는 테스트 추가

## 🔎 작업 상세 설명

게시글 등록, 수정 시 이미지 10개 검증 로직을 추가
- 이미지 개수 검증의 위치를 최대한 도메인으로 집어넣고 싶었으나, 이미지 파일이 생성되어 디렉토리에 저장되기 전에 이미지 개수 검증을 하기 위해 적당히 서비스와 타협하였습니다. 😭 그래서 현재 서비스에서 Post 클래스의 isValidImageNumber 메서드를 호출해서 이미지 개수를 검증하고 있습니다만, 좋은 의견 있으시면 코멘투 주세요 ~! 적극 반영해보겠습니다~
- 관련 테스트 코드를 추가했습니다. (PostServiceTest)

테스트할때 이미지가 생성되어 저장되는 테스트 클래스들에 `@AfterEach`로 테스트가 끝난 후 해당 디렉토리의 이미지 파일들을 삭제하는 테스트 추가
- Post 관련 테스트들 중, 이미지를 생성하는 테스트 클래스들에게 테스트가 끝난 후 이미지 파일 지우는 코드를 추가했습니다.

