### PR TITLE
feat: prod 환경에서 mysql을 사용하도록 설정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -45,6 +45,8 @@ dependencies {
 
 	// rest assured 추가
 	testImplementation 'io.rest-assured:rest-assured:5.3.1'
+
+	implementation 'com.mysql:mysql-connector-j'
 }
 
 tasks.named('test') {

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -1,8 +1,8 @@
-spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL57Dialect
-spring.jpa.hibernate.ddl-auto=update
-spring.datasource.username=sa
-spring.h2.console.enabled=true
+spring.datasource.url=${MYSQL_ADDRESS}
+spring.datasource.username=${MYSQL_USERNAME}
+spring.datasource.password=${MYSQL_PASSWORD}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
 file.dir=/home/ubuntu/2023-edonymyeon/resources/
 domain=http://edonymyeon.site/images/
 spring.servlet.multipart.max-file-size=20MB


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #165 

## 📝 작업 요약

* 운영 환경(prod) 에서는 ec2에 설치된 mySQL 데이터베이스를 사용합니다.
* 운영 데이터베이스가 내려가지 않도록 ddl-auto 설정을 삭제했습니다.
* 데이터베이스 주소, username과 password는 ec2 내부의 환경변수를 사용하고, 애플리케이션은 해당 환경변수를 사용하도록 하여 내부정보 유출을 방지합니다.