### PR TITLE
Refactor/#176 로그인 로직 수정

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
+++ b/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
@@ -23,15 +23,16 @@ public class AuthService {
 
     private final MemberRepository memberRepository;
 
-    //todo: 비밀번호까지 조회에 사용하나?
-    public MemberIdDto findMember(final String email, final String password) {
-        final Member member = memberRepository.findByEmailAndPassword(email, password)
-                .orElseThrow(() -> new EdonymyeonException(MEMBER_EMAIL_NOT_FOUND));
-        return new MemberIdDto(member.getId());
-    }
-
     public MemberIdDto findMember(final LoginRequest loginRequest) {
         return findMember(loginRequest.email(), loginRequest.password());
+    }
+
+    //todo: 비밀번호까지 조회에 사용하나?
+    public MemberIdDto findMember(final String email, final String password) {
+        final Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new EdonymyeonException(MEMBER_EMAIL_NOT_FOUND));
+        member.checkPassword(password);
+        return new MemberIdDto(member.getId());
     }
 
     public DuplicateCheckResponse checkDuplicate(final String target, final String value) {

--- a/backend/src/main/java/edonymyeon/backend/global/exception/ExceptionInformation.java
+++ b/backend/src/main/java/edonymyeon/backend/global/exception/ExceptionInformation.java
@@ -13,6 +13,7 @@ public enum ExceptionInformation {
     // 클래스이름_필드명_틀린내용
     // 1___: 인증 관련
     MEMBER_EMAIL_NOT_FOUND(1511, "회원의 이메일이 존재하지 않습니다."),
+    MEMBER_PASSWORD_NOT_MATCH(1512, "회원의 비밀번호가 일치하지 않습니다."),
     AUTHORIZATION_EMPTY(1523, "인증 정보가 없습니다."),
     ILLEGAL_ARGUMENT_TYPE(1524, "잘못된 타입의 요청입니다."),
 

--- a/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
+++ b/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
@@ -3,6 +3,7 @@ package edonymyeon.backend.member.domain;
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_EMAIL_INVALID;
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_NICKNAME_INVALID;
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_PASSWORD_INVALID;
+import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_PASSWORD_NOT_MATCH;
 
 import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.image.profileimage.domain.ProfileImageInfo;
@@ -81,5 +82,12 @@ public class Member {
             return;
         }
         throw new EdonymyeonException(MEMBER_PASSWORD_INVALID);
+    }
+
+    public void checkPassword(final String password) {
+        if (this.password.equals(password)) {
+            return;
+        }
+        throw new EdonymyeonException(MEMBER_PASSWORD_NOT_MATCH);
     }
 }

--- a/backend/src/main/java/edonymyeon/backend/member/repository/MemberRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/member/repository/MemberRepository.java
@@ -6,8 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByEmailAndPassword(final String email, final String password);
-
     Optional<Member> findByEmail(final String email);
 
     Optional<Member> findByNickname(final String nickname);

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -14,4 +14,4 @@ spring.jpa.open-in-view=false
 
 spring.jpa.defer-datasource-initialization=true
 spring.sql.init.data-locations=classpath:data.sql
-spring.sql.init.mode=always
+spring.sql.init.mode=never


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #176 

## 📝 작업 요약

- 로그인 로직을 수정하였습니다.
- 배포환경에서 더미 데이터가 추가되지 않도록 수정하였습니다.

## 🔎 작업 상세 설명

- 기존 DB에서 아이디, 비밀번호로 조회하던 걸, 아이디로 가져와서 회원 객체에서 비밀번호 검증을 하도록 수정하였습니다.

## 🌟 리뷰 요구 사항

> 리뷰 예상 시간 및 집중 리뷰 부분을 작성해주세요.
