### PR TITLE
fix: 인터셉터 진입 전에 예외가 터졌을 시 예외응답이 반환되지 않는 버그 수정

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/global/logging/LoggingFilter.java
+++ b/backend/src/main/java/edonymyeon/backend/global/logging/LoggingFilter.java
@@ -27,5 +27,6 @@ public class LoggingFilter implements Filter {
                 (HttpServletResponse) response);
 
         chain.doFilter(request, httpServletResponse);
+        httpServletResponse.copyBodyToResponse();
     }
 }

--- a/backend/src/main/java/edonymyeon/backend/global/logging/LoggingInterceptor.java
+++ b/backend/src/main/java/edonymyeon/backend/global/logging/LoggingInterceptor.java
@@ -47,7 +47,6 @@ public class LoggingInterceptor implements HandlerInterceptor {
     private void logResponseBody(final HttpServletResponse response) throws IOException {
         ContentCachingResponseWrapper responseWrapper = getResponseWrapper(response);
         log.info("body {} ", getResponseBody(responseWrapper));
-        responseWrapper.copyBodyToResponse();
     }
 
     private String getResponseBody(ContentCachingResponseWrapper responseWrapper) {


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #179 

## 📝 작업 요약

인터셉터 진입 전에 예외가 터졌을 시 예외응답이 반환되지 않는 버그를 수정하였습니다.
