### PR TITLE
fix: transactional 어노테이션 빠뜨린 것 추가

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/member/application/MemberService.java
+++ b/backend/src/main/java/edonymyeon/backend/member/application/MemberService.java
@@ -29,6 +29,7 @@ public class MemberService {
         return new MyPageResponse(member.getId(), member.getNickname());
     }
 
+    @Transactional
     public void confirmPurchase(
             final MemberIdDto memberIdDto,
             final Long postId,
@@ -40,6 +41,7 @@ public class MemberService {
                 yearMonthDto);
     }
 
+    @Transactional
     public void confirmSaving(
             final MemberIdDto memberIdDto,
             final Long postId,
@@ -49,6 +51,7 @@ public class MemberService {
         consumptionConfirmService.confirmSaving(memberIdDto, postId, yearMonthDto);
     }
 
+    @Transactional
     public void removeConfirm(final MemberIdDto memberIdDto, final Long postId) {
         consumptionConfirmService.removeConfirm(memberIdDto, postId);
     }


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #182 

## 📝 작업 요약

MemberService에 `@Transactional` 어노테이션을 빠뜨려 `@Transactional(readOnly=true)`가 적용되는 부분을 수정하였습니다
