### PR TITLE
refactor: 게시글 등록 조건 수정

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/global/exception/ExceptionInformation.java
+++ b/backend/src/main/java/edonymyeon/backend/global/exception/ExceptionInformation.java
@@ -20,7 +20,7 @@ public enum ExceptionInformation {
     // 2___: 게시글 관련
     POST_ID_NOT_FOUND(2000, "존재하지 않는 게시글입니다."),
     POST_TITLE_ILLEGAL_LENGTH(2511, "제목은 1자 이상 30자 이하여야 합니다."),
-    POST_CONTENT_ILLEGAL_LENGTH(2523, "내용은 1자 이상 1,000자 이하여야 합니다."),
+    POST_CONTENT_ILLEGAL_LENGTH(2523, "내용은 0자 이상 1,000자 이하여야 합니다."),
     POST_PRICE_ILLEGAL_SIZE(2543, "가격은 0원 이상 100억 이하여야 합니다."),
     POST_MEMBER_EMPTY(2544, "게시글에는 작성자가 있어야 합니다."),
     POST_MEMBER_NOT_SAME(2666, "게시글 작성자가 아닙니다."),

--- a/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
+++ b/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
@@ -104,7 +104,7 @@ public class Post {
     }
 
     private void validateContent(final String content) {
-        if (content.isBlank() || content.length() > MAX_CONTENT_LENGTH) {
+        if (Objects.isNull(content) || content.length() > MAX_CONTENT_LENGTH) {
             throw new EdonymyeonException(POST_CONTENT_ILLEGAL_LENGTH);
         }
     }

--- a/backend/src/test/java/edonymyeon/backend/post/integration/PostIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/integration/PostIntegrationTest.java
@@ -85,6 +85,23 @@ public class PostIntegrationTest extends IntegrationTest implements ImageFileCle
     }
 
     @Test
+    void 게시글을_작성할_때_내용은_0자_이상_가능하다() {
+        final Member 작성자 = 사용자를_하나_만든다();
+        final var response = RestAssured.given()
+                .multiPart("title", "this is title")
+                .multiPart("content", "")
+                .multiPart("price", 1000)
+                .multiPart("images", 이미지1, MediaType.IMAGE_JPEG_VALUE)
+                .auth().preemptive().basic(작성자.getEmail(), 작성자.getPassword())
+                .when()
+                .post("/posts")
+                .then()
+                .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    @Test
     void 게시글을_작성할때_이미지가_10개_이상이면_예외가_발생한다() {
         final Member 작성자 = 사용자를_하나_만든다();
         final ExtractableResponse<Response> 게시글_작성_응답 = RestAssured.given()


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #184 

## 📝 작업 요약

안드로이드에서 null값이 "null" 문자열로 보내는 이슈가 있어, ""로 대신해 보내는 전략으로 변경하였습니다.
이에따라 백엔드에서는 게시글 등록 조건에서, 내용 글자수 제한을 0자 이상으로 완화하였습니다.

