### PR TITLE
fix: 카메라로 사진 찍었을 때 어댑터에 바로 반영안되는 오류 수정

### DIFF
--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/posteditor/PostEditorViewModel.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/posteditor/PostEditorViewModel.kt
@@ -43,10 +43,6 @@ class PostEditorViewModel(
     val postId: LiveData<Long>
         get() = _postId
 
-    init {
-        _galleryImages.value = images
-    }
-
     fun initViewModelOnUpdate(post: PostUiModel) {
         _postTitle.value = post.title
         _postPrice.value = post.price.toString()


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #158 

## 📝 작업 요약

카메라로 사진 찍었을 때 어댑터에 바로 반영안되는 오류를 수정했습니다.

## 🔎 작업 상세 설명

viewModel의 init 코드 때문이어서 그 코드 부분만 삭제했습니다.

## 🌟 리뷰 요구 사항

추후 코드에 대한 리팩토링 이슈가 파져있어서 그 이슈에서 리팩토링을 진행할 예정이기 때문에 오류가 수정되어 기능이 잘 동작하는지만 봐주시면 좋을 것 같습니다!
