### PR TITLE
Feat: 핫 게시글을 정책에 따라 조회하는 기능 구현

### DIFF
--- a/backend/src/docs/asciidoc/common/post-api.adoc
+++ b/backend/src/docs/asciidoc/common/post-api.adoc
@@ -5,6 +5,9 @@
 // 'generated-snippets의 하위디렉토리명[]' <- 이 형태로 [] 안에는 원하는 스니펫 순서대로 넣으면 됨. 제목까지 알아서 생성해줌.
 operation::post-create[snippets='request-headers,request-parts,http-request,http-response,response-fields']
 
+=== 핫 게시글 조회
+operation::post-hotPosts[snippets='query-parameters,http-request,http-response']
+
 === 게시글 전체 조회
 operation::post-findAll[snippets='query-parameters,http-request,http-response']
 

--- a/backend/src/main/java/edonymyeon/backend/global/config/WebMvcConfiguration.java
+++ b/backend/src/main/java/edonymyeon/backend/global/config/WebMvcConfiguration.java
@@ -2,13 +2,15 @@ package edonymyeon.backend.global.config;
 
 import edonymyeon.backend.auth.ui.argumentresolver.AuthArgumentResolver;
 import edonymyeon.backend.logging.LoggingInterceptor;
+import edonymyeon.backend.post.ui.argumentresolver.HotPostSizingArgumentResolver;
 import edonymyeon.backend.post.ui.argumentresolver.PostPagingArgumentResolver;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Configuration
@@ -16,11 +18,13 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
 
     private final AuthArgumentResolver authArgumentResolver;
     private final PostPagingArgumentResolver postPagingArgumentResolver;
+    private final HotPostSizingArgumentResolver hotPostSizingArgumentResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(authArgumentResolver);
         resolvers.add(postPagingArgumentResolver);
+        resolvers.add(hotPostSizingArgumentResolver);
     }
 
     @Override

--- a/backend/src/main/java/edonymyeon/backend/post/application/GeneralFindingCondition.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/GeneralFindingCondition.java
@@ -1,18 +1,23 @@
 package edonymyeon.backend.post.application;
 
-import static edonymyeon.backend.global.exception.ExceptionInformation.POST_INVALID_PAGINATION_CONDITION;
-
 import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.post.application.dto.SortBy;
 import edonymyeon.backend.post.application.dto.SortDirection;
 import edonymyeon.backend.post.domain.Post;
-import java.util.Objects;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 
+import java.util.Objects;
+
+import static edonymyeon.backend.global.exception.ExceptionInformation.POST_INVALID_PAGINATION_CONDITION;
+
+/**
+ * 보통의 게시글 목록을 조회하는 정책
+ * page, size, sort 기준, sort 순서 조건을 입력 받는다
+ */
 @Builder
 @Getter
 public class GeneralFindingCondition {
@@ -33,6 +38,14 @@ public class GeneralFindingCondition {
     @Builder.Default
     private final SortDirection sortDirection = DEFAULT_SORT_DIRECTION;
 
+    /**
+     *
+     * @param page 페이지 인덱스 (기본 값은 0)
+     * @param size 페이지 당 사이즈 (기본 값은 20)
+     * @param sortBy 페이지 정렬 조건 (기본 값은 작성일)
+     * @param sortDirection 페이지 정렬 순서 (기본 값은 최신순)
+     * @return GeneralFindingCondition
+     */
     public static GeneralFindingCondition of(
             final Integer page,
             final Integer size,
@@ -48,6 +61,12 @@ public class GeneralFindingCondition {
                 .build();
     }
 
+    /**
+     * 페이징 조건을 토대로 pageRequest 객체를 만든다
+     * 조건에 맞지 않는 파라미터라면 2700 오류를 내려보낸다
+     *
+     * @return PageRequest
+     */
     public Pageable toPage() {
         try {
             return PageRequest.of(

--- a/backend/src/main/java/edonymyeon/backend/post/application/HotFindingCondition.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/HotFindingCondition.java
@@ -1,0 +1,46 @@
+package edonymyeon.backend.post.application;
+
+import edonymyeon.backend.global.exception.EdonymyeonException;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Objects;
+
+import static edonymyeon.backend.global.exception.ExceptionInformation.POST_INVALID_PAGINATION_CONDITION;
+
+@Builder
+@Getter
+public class HotFindingCondition {
+
+    public static final int DEFAULT_PAGE = 0;
+    public static final int DEFAULT_SIZE = 5;
+
+    @Builder.Default
+    private final Integer page = DEFAULT_PAGE;
+
+    @Builder.Default
+    private final Integer size = DEFAULT_SIZE;
+
+    public static HotFindingCondition of(
+            final Integer page,
+            final Integer size
+    ) {
+        return HotFindingCondition.builder()
+                .page(Objects.isNull(page) ? HotFindingCondition.DEFAULT_PAGE : page)
+                .size(Objects.isNull(size) ? HotFindingCondition.DEFAULT_SIZE : size)
+                .build();
+    }
+
+    public Pageable toPage() {
+        try {
+            return PageRequest.of(
+                    page,
+                    size
+            );
+        } catch (IllegalArgumentException e) {
+            throw new EdonymyeonException(POST_INVALID_PAGINATION_CONDITION);
+        }
+    }
+}

--- a/backend/src/main/java/edonymyeon/backend/post/application/HotFindingCondition.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/HotFindingCondition.java
@@ -10,6 +10,10 @@ import java.util.Objects;
 
 import static edonymyeon.backend.global.exception.ExceptionInformation.POST_INVALID_PAGINATION_CONDITION;
 
+/**
+ * 핫 게시글의 목록을 조회하는 정책
+ * page 와 size 정보를 받는다.
+ */
 @Builder
 @Getter
 public class HotFindingCondition {
@@ -23,6 +27,12 @@ public class HotFindingCondition {
     @Builder.Default
     private final Integer size = DEFAULT_SIZE;
 
+    /**
+     *
+     * @param page 페이지 인덱스 (기본 값은 0)
+     * @param size 페이지 당 사이즈 (기본 값은 5)
+     * @return HotFindingCondition
+     */
     public static HotFindingCondition of(
             final Integer page,
             final Integer size
@@ -33,6 +43,12 @@ public class HotFindingCondition {
                 .build();
     }
 
+    /**
+     * 페이징 조건을 토대로 pageRequest 객체를 만든다
+     * 조건에 맞지 않는 파라미터라면 2700 오류를 내려보낸다
+     *
+     * @return PageRequest
+     */
     public Pageable toPage() {
         try {
             return PageRequest.of(

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostReadService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostReadService.java
@@ -125,13 +125,14 @@ public class PostReadService {
         return PostSlice.from(foundPosts);
     }
 
-    public Slice<GeneralPostInfoResponse> findHotPosts(final HotFindingCondition hotFindingCondition) {
+    public PostSlice<GeneralPostInfoResponse> findHotPosts(final HotFindingCondition hotFindingCondition) {
         Slice<Post> hotPost = postRepository.findHotPosts(
                 HotPostPolicy.getFindPeriod(),
                 HotPostPolicy.VIEW_COUNT_WEIGHT,
                 HotPostPolicy.THUMBS_COUNT_WEIGHT,
                 hotFindingCondition.toPage()
         );
-        return hotPost.map(post -> GeneralPostInfoResponse.of(post, domain.getDomain()));
+        Slice<GeneralPostInfoResponse> hotPostSlice = hotPost.map(post -> GeneralPostInfoResponse.of(post, domain.getDomain()));
+        return PostSlice.from(hotPostSlice);
     }
 }

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostReadService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostReadService.java
@@ -18,8 +18,6 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -126,16 +124,12 @@ public class PostReadService {
     }
 
     public Slice<GeneralPostInfoResponse> findHotPosts(final HotFindingCondition hotFindingCondition) {
-        final LocalDateTime findStartDate = LocalDateTime.now()
-                .minus(HotPostPolicy.FINDING_PERIOD, ChronoUnit.DAYS);
-
         Slice<Post> hotPost = postRepository.findHotPosts(
-                findStartDate,
+                HotPostPolicy.getFindPeriod(),
                 HotPostPolicy.VIEW_COUNT_WEIGHT,
                 HotPostPolicy.THUMBS_COUNT_WEIGHT,
                 hotFindingCondition.toPage()
         );
-
         return hotPost.map(post -> GeneralPostInfoResponse.of(post, domain.getDomain()));
     }
 }

--- a/backend/src/main/java/edonymyeon/backend/post/domain/HotPostPolicy.java
+++ b/backend/src/main/java/edonymyeon/backend/post/domain/HotPostPolicy.java
@@ -1,0 +1,10 @@
+package edonymyeon.backend.post.domain;
+
+public class HotPostPolicy {
+
+    public static final int FINDING_PERIOD = 7;
+
+    public static final int VIEW_COUNT_WEIGHT = 1;
+
+    public static final int THUMBS_COUNT_WEIGHT = 3;
+}

--- a/backend/src/main/java/edonymyeon/backend/post/domain/HotPostPolicy.java
+++ b/backend/src/main/java/edonymyeon/backend/post/domain/HotPostPolicy.java
@@ -1,5 +1,8 @@
 package edonymyeon.backend.post.domain;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
 public class HotPostPolicy {
 
     public static final int FINDING_PERIOD = 7;
@@ -7,4 +10,9 @@ public class HotPostPolicy {
     public static final int VIEW_COUNT_WEIGHT = 1;
 
     public static final int THUMBS_COUNT_WEIGHT = 3;
+
+    public static LocalDateTime getFindPeriod(){
+        return LocalDateTime.now()
+                .minus(FINDING_PERIOD, ChronoUnit.DAYS);
+    }
 }

--- a/backend/src/main/java/edonymyeon/backend/post/repository/PostRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/post/repository/PostRepository.java
@@ -30,12 +30,12 @@ public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificat
 
     @EntityGraph(attributePaths = "member")
     @Query("""
-            SELECT p 
-            FROM Post p 
-            LEFT JOIN Thumbs t 
-            ON p.id = t.post.id 
-            WHERE p.createdAt >= :findStartDate 
-            GROUP BY p.id 
+            SELECT p
+            FROM Post p
+            LEFT JOIN Thumbs t
+            ON p.id = t.post.id
+            WHERE p.createdAt >= :findStartDate
+            GROUP BY p.id
             ORDER BY (COUNT(t.id) * :thumbsCountWeight + p.viewCount * :viewCountWeight) DESC, p.createdAt ASC
             """)
     Slice<Post> findHotPosts(

--- a/backend/src/main/java/edonymyeon/backend/post/repository/PostRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/post/repository/PostRepository.java
@@ -9,7 +9,11 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.lang.NonNull;
+
+import java.time.LocalDateTime;
 
 public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificationExecutor<Post> {
 
@@ -23,4 +27,18 @@ public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificat
 
     @EntityGraph(attributePaths = "member")
     Slice<Post> findAllByMemberId(Long memberId, Pageable pageable);
+
+    @EntityGraph(attributePaths = "member")
+    @Query("SELECT p " +
+            "FROM Post p " +
+            "LEFT JOIN Thumbs t " +
+            "ON p.id = t.post.id " +
+            "WHERE p.createdAt >= :findStartDate " +
+            "GROUP BY p.id " +
+            "ORDER BY (COUNT(t.id) * :thumbsCountWeight + p.viewCount * :viewCountWeight) DESC, p.createdAt ASC")
+    Slice<Post> findHotPosts(
+            @Param("findStartDate") final LocalDateTime findStartDate,
+            @Param("viewCountWeight") final int viewCountWeight,
+            @Param("thumbsCountWeight") final int thumbsCountWeight,
+            Pageable pageable);
 }

--- a/backend/src/main/java/edonymyeon/backend/post/repository/PostRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/post/repository/PostRepository.java
@@ -29,13 +29,15 @@ public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificat
     Slice<Post> findAllByMemberId(Long memberId, Pageable pageable);
 
     @EntityGraph(attributePaths = "member")
-    @Query("SELECT p " +
-            "FROM Post p " +
-            "LEFT JOIN Thumbs t " +
-            "ON p.id = t.post.id " +
-            "WHERE p.createdAt >= :findStartDate " +
-            "GROUP BY p.id " +
-            "ORDER BY (COUNT(t.id) * :thumbsCountWeight + p.viewCount * :viewCountWeight) DESC, p.createdAt ASC")
+    @Query("""
+            SELECT p 
+            FROM Post p 
+            LEFT JOIN Thumbs t 
+            ON p.id = t.post.id 
+            WHERE p.createdAt >= :findStartDate 
+            GROUP BY p.id 
+            ORDER BY (COUNT(t.id) * :thumbsCountWeight + p.viewCount * :viewCountWeight) DESC, p.createdAt ASC
+            """)
     Slice<Post> findHotPosts(
             @Param("findStartDate") final LocalDateTime findStartDate,
             @Param("viewCountWeight") final int viewCountWeight,

--- a/backend/src/main/java/edonymyeon/backend/post/ui/PostReadController.java
+++ b/backend/src/main/java/edonymyeon/backend/post/ui/PostReadController.java
@@ -40,12 +40,12 @@ public class PostReadController {
     }
 
     @GetMapping("/posts/hot")
-    public ResponseEntity<Slice<GeneralPostInfoResponse>> findHotPosts(
+    public ResponseEntity<PostSlice<GeneralPostInfoResponse>> findHotPosts(
             @HotPostSizing HotFindingCondition hotFindingCondition
     ) {
-        Slice<GeneralPostInfoResponse> posts = postReadService.findHotPosts(hotFindingCondition);
+        PostSlice<GeneralPostInfoResponse> hotPosts = postReadService.findHotPosts(hotFindingCondition);
         return ResponseEntity.ok()
-                .body(posts);
+                .body(hotPosts);
     }
 
     @GetMapping("/search")

--- a/backend/src/main/java/edonymyeon/backend/post/ui/PostReadController.java
+++ b/backend/src/main/java/edonymyeon/backend/post/ui/PostReadController.java
@@ -3,9 +3,11 @@ package edonymyeon.backend.post.ui;
 import edonymyeon.backend.auth.annotation.AuthPrincipal;
 import edonymyeon.backend.member.application.dto.MemberId;
 import edonymyeon.backend.post.application.GeneralFindingCondition;
+import edonymyeon.backend.post.application.HotFindingCondition;
 import edonymyeon.backend.post.application.PostReadService;
 import edonymyeon.backend.post.application.dto.GeneralPostInfoResponse;
 import edonymyeon.backend.post.application.dto.SpecificPostInfoResponse;
+import edonymyeon.backend.post.ui.annotation.HotPostSizing;
 import edonymyeon.backend.post.ui.annotation.PostPaging;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
@@ -35,6 +37,15 @@ public class PostReadController {
         SpecificPostInfoResponse specificPost = postReadService.findSpecificPost(postId, memberId);
         return ResponseEntity.ok()
                 .body(specificPost);
+    }
+
+    @GetMapping("/posts/hot")
+    public ResponseEntity<Slice<GeneralPostInfoResponse>> findHotPosts(
+            @HotPostSizing HotFindingCondition hotFindingCondition
+    ) {
+        Slice<GeneralPostInfoResponse> posts = postReadService.findHotPosts(hotFindingCondition);
+        return ResponseEntity.ok()
+                .body(posts);
     }
 
     @GetMapping("/search")

--- a/backend/src/main/java/edonymyeon/backend/post/ui/annotation/HotPostSizing.java
+++ b/backend/src/main/java/edonymyeon/backend/post/ui/annotation/HotPostSizing.java
@@ -1,0 +1,12 @@
+package edonymyeon.backend.post.ui.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HotPostSizing {
+
+}

--- a/backend/src/main/java/edonymyeon/backend/post/ui/annotation/HotPostSizing.java
+++ b/backend/src/main/java/edonymyeon/backend/post/ui/annotation/HotPostSizing.java
@@ -5,6 +5,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * 핫 게시글의 목록을 조회하는 정책
+ * page 와 size 정보를 받는다.
+ */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface HotPostSizing {

--- a/backend/src/main/java/edonymyeon/backend/post/ui/annotation/PostPaging.java
+++ b/backend/src/main/java/edonymyeon/backend/post/ui/annotation/PostPaging.java
@@ -5,6 +5,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * 보통의 게시글 목록을 조회하는 정책
+ * page, size, sort 기준, sort 순서 조건을 입력 받는다
+ */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface PostPaging {

--- a/backend/src/main/java/edonymyeon/backend/post/ui/argumentresolver/HotPostSizingArgumentResolver.java
+++ b/backend/src/main/java/edonymyeon/backend/post/ui/argumentresolver/HotPostSizingArgumentResolver.java
@@ -1,0 +1,47 @@
+package edonymyeon.backend.post.ui.argumentresolver;
+
+import edonymyeon.backend.global.exception.EdonymyeonException;
+import edonymyeon.backend.global.exception.ExceptionInformation;
+import edonymyeon.backend.post.application.HotFindingCondition;
+import edonymyeon.backend.post.ui.annotation.HotPostSizing;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.Objects;
+
+@Component
+public class HotPostSizingArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.getParameterType().equals(HotFindingCondition.class)
+                && parameter.hasParameterAnnotation(HotPostSizing.class);
+    }
+
+    @Override
+    public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
+                                  final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
+        final String page = webRequest.getParameter("page");
+        final String size = webRequest.getParameter("size");
+
+        return HotFindingCondition.of(
+                convertToNumber(page),
+                convertToNumber(size)
+        );
+    }
+
+    private static Integer convertToNumber(final String target) {
+        if (Objects.nonNull(target)) {
+            try {
+                return Integer.parseInt(target);
+            } catch (NumberFormatException e) {
+                throw new EdonymyeonException(ExceptionInformation.POST_INVALID_PAGINATION_CONDITION);
+            }
+        }
+        return null;
+    }
+}

--- a/backend/src/test/java/edonymyeon/backend/post/integration/HotPostIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/integration/HotPostIntegrationTest.java
@@ -1,0 +1,92 @@
+package edonymyeon.backend.post.integration;
+
+import edonymyeon.backend.IntegrationTest;
+import edonymyeon.backend.member.application.dto.ActiveMemberId;
+import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.post.application.PostReadService;
+import edonymyeon.backend.post.domain.Post;
+import edonymyeon.backend.thumbs.domain.Thumbs;
+import edonymyeon.backend.thumbs.domain.ThumbsType;
+import edonymyeon.backend.thumbs.repository.ThumbsRepository;
+import io.restassured.RestAssured;
+import io.restassured.path.json.JsonPath;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class HotPostIntegrationTest extends IntegrationTest {
+
+    @Autowired
+    ThumbsRepository thumbsRepository;
+
+    @Autowired
+    PostReadService postReadService;
+
+    @Test
+    void 핫게시글이_순서대로_찾아지는지_확인한다() {
+        // given
+        Post post1 = postTestSupport.builder().build();
+        Post post2 = postTestSupport.builder().build();
+        Post post3 = postTestSupport.builder().build();
+        Post post4 = postTestSupport.builder().build();
+        Post post5 = postTestSupport.builder().build();
+
+        Member member = memberTestSupport.builder().build();
+
+        // when
+        thumbsRepository.save(new Thumbs(post4, member, ThumbsType.UP)); // 좋아요 1번
+
+        thumbsRepository.save(new Thumbs(post5, member, ThumbsType.UP)); // 좋아요 1번
+        postReadService.findSpecificPost(post5.getId(), new ActiveMemberId(member.getId())); // 조회 1번
+
+        // then
+        JsonPath jsonPath = RestAssured.given()
+                .when()
+                .get("posts/hot")
+                .then()
+                .extract()
+                .body()
+                .jsonPath();
+
+        assertSoftly(softly -> {
+                    softly.assertThat(jsonPath.getList("content").size()).isEqualTo(5);
+                    softly.assertThat(jsonPath.getLong("content[0].id")).isEqualTo(post5.getId());
+                    softly.assertThat(jsonPath.getLong("content[1].id")).isEqualTo(post4.getId());
+                    softly.assertThat(jsonPath.getLong("content[2].id")).isEqualTo(post1.getId());
+                    softly.assertThat(jsonPath.getLong("content[3].id")).isEqualTo(post2.getId());
+                    softly.assertThat(jsonPath.getLong("content[4].id")).isEqualTo(post3.getId());
+                }
+        );
+    }
+
+    @Test
+    void 핫_게시글이_없다면_오래된_순서로_찾아온다() {
+        // given, when
+        Post post1 = postTestSupport.builder().build();
+        Post post2 = postTestSupport.builder().build();
+        Post post3 = postTestSupport.builder().build();
+        Post post4 = postTestSupport.builder().build();
+        Post post5 = postTestSupport.builder().build();
+
+        // then
+        JsonPath jsonPath = RestAssured.given()
+                .when()
+                .get("posts/hot")
+                .then()
+                .extract()
+                .body()
+                .jsonPath();
+
+        assertSoftly(softly -> {
+                    softly.assertThat(jsonPath.getList("content").size()).isEqualTo(5);
+                    softly.assertThat(jsonPath.getLong("content[0].id")).isEqualTo(post1.getId());
+                    softly.assertThat(jsonPath.getLong("content[1].id")).isEqualTo(post2.getId());
+                    softly.assertThat(jsonPath.getLong("content[2].id")).isEqualTo(post3.getId());
+                    softly.assertThat(jsonPath.getLong("content[3].id")).isEqualTo(post4.getId());
+                    softly.assertThat(jsonPath.getLong("content[4].id")).isEqualTo(post5.getId());
+                }
+        );
+    }
+}

--- a/backend/src/test/java/edonymyeon/backend/post/integration/HotPostIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/integration/HotPostIntegrationTest.java
@@ -13,6 +13,7 @@ import io.restassured.path.json.JsonPath;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -88,5 +89,18 @@ public class HotPostIntegrationTest extends IntegrationTest {
                     softly.assertThat(jsonPath.getLong("content[4].id")).isEqualTo(post5.getId());
                 }
         );
+    }
+
+    @Test
+    void 최근_일주일_이내의_글이_없다면_빈리스트가_조회된다() {
+        JsonPath jsonPath = RestAssured.given()
+                .when()
+                .get("posts/hot")
+                .then()
+                .extract()
+                .body()
+                .jsonPath();
+
+        assertThat(jsonPath.getList("content").size()).isEqualTo(0);
     }
 }

--- a/backend/src/test/java/edonymyeon/backend/post/repository/PostRepositoryTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/repository/PostRepositoryTest.java
@@ -1,19 +1,28 @@
 package edonymyeon.backend.post.repository;
 
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
+import edonymyeon.backend.member.application.dto.AnonymousMemberId;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.repository.MemberRepository;
+import edonymyeon.backend.post.application.HotFindingCondition;
+import edonymyeon.backend.post.application.PostReadService;
+import edonymyeon.backend.post.domain.HotPostPolicy;
 import edonymyeon.backend.post.domain.Post;
+import edonymyeon.backend.support.PostTestSupport;
+import edonymyeon.backend.support.ThumbsUpPostTestSupport;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.test.context.TestConstructor.AutowireMode;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @Transactional
 @SuppressWarnings("NonAsciiCharacters")
@@ -26,6 +35,15 @@ class PostRepositoryTest {
     private final PostRepository postRepository;
 
     private final MemberRepository memberRepository;
+
+    private final PostReadService postReadService;
+
+    private final ThumbsUpPostTestSupport thumbsPostTestSupport;
+
+    private final PostTestSupport postTestSupport;
+
+    private final Pageable page = HotFindingCondition.of(0,5).toPage();
+
     private Member member;
 
     @BeforeEach
@@ -52,6 +70,125 @@ class PostRepositoryTest {
                     softly.assertThat(target.getCreatedAt()).isNotNull();
                     softly.assertThat(target.getViewCount()).isEqualTo(0L);
                     softly.assertThat(target.getMember().getId()).isEqualTo(member.getId());
+                }
+        );
+    }
+
+    @Test
+    void 최근_게시글이_없다면_빈_리스트가_조회된다() {
+        Slice<Post> hotPosts = postRepository.findHotPosts(
+                HotPostPolicy.getFindPeriod(),
+                HotPostPolicy.VIEW_COUNT_WEIGHT,
+                HotPostPolicy.THUMBS_COUNT_WEIGHT,
+                page);
+
+        assertThat(hotPosts.isEmpty()).isTrue();
+    }
+
+    @Test
+    void findHotPosts_메서드에서_thumbs_테이블에_정보가_없어도_제대로_조인되는지_확인한다() {
+        // given
+        Post post1 = postTestSupport.builder().build();
+        Post post2 = postTestSupport.builder().build();
+
+        // when
+        thumbsPostTestSupport.builder().post(post1).build();
+
+        // then
+        Slice<Post> hotPosts = postRepository.findHotPosts(
+                HotPostPolicy.getFindPeriod(),
+                HotPostPolicy.VIEW_COUNT_WEIGHT,
+                HotPostPolicy.THUMBS_COUNT_WEIGHT,
+                page);
+
+        for (Post hotPost : hotPosts) {
+            System.out.println("hotPost = " + hotPost.getId() + hotPost.getTitle());
+        }
+
+        assertSoftly(softly -> {
+                    softly.assertThat(hotPosts.get().toList().size()).isEqualTo(2);
+                    softly.assertThat(hotPosts.get().toList().get(0).getId()).isEqualTo(post1.getId());
+                    softly.assertThat(hotPosts.get().toList().get(1).getId()).isEqualTo(post2.getId());
+                }
+        );
+    }
+
+    @Test
+    void 인기순_대로_게시글이_조회되는지_확인한다() {
+        // given
+        Post score8Post = postTestSupport.builder().build();
+        Post score6Post = postTestSupport.builder().build();
+        Post score9Post = postTestSupport.builder().build();
+        Post score10Post = postTestSupport.builder().build();
+        Post score5Post = postTestSupport.builder().build();
+
+        // when
+        thumbsPostTestSupport.builder().post(score8Post).build();
+        thumbsPostTestSupport.builder().post(score8Post).build();
+        postReadService.findSpecificPost(score8Post.getId(), new AnonymousMemberId());
+        postReadService.findSpecificPost(score8Post.getId(), new AnonymousMemberId());
+
+        thumbsPostTestSupport.builder().post(score6Post).build();
+        thumbsPostTestSupport.builder().post(score6Post).build();
+
+        thumbsPostTestSupport.builder().post(score9Post).build();
+        thumbsPostTestSupport.builder().post(score9Post).build();
+        thumbsPostTestSupport.builder().post(score9Post).build();
+
+        thumbsPostTestSupport.builder().post(score10Post).build();
+        thumbsPostTestSupport.builder().post(score10Post).build();
+        thumbsPostTestSupport.builder().post(score10Post).build();
+        postReadService.findSpecificPost(score10Post.getId(), new AnonymousMemberId());
+
+        thumbsPostTestSupport.builder().post(score5Post).build();
+        postReadService.findSpecificPost(score5Post.getId(), new AnonymousMemberId());
+        postReadService.findSpecificPost(score5Post.getId(), new AnonymousMemberId());
+
+        // then
+        Slice<Post> hotPosts = postRepository.findHotPosts(
+                HotPostPolicy.getFindPeriod(),
+                HotPostPolicy.VIEW_COUNT_WEIGHT,
+                HotPostPolicy.THUMBS_COUNT_WEIGHT,
+                page);
+
+        assertSoftly(softly -> {
+                    softly.assertThat(hotPosts.get().toList().size()).isEqualTo(5);
+                    softly.assertThat(hotPosts.get().toList().get(0).getId()).isEqualTo(score10Post.getId());
+                    softly.assertThat(hotPosts.get().toList().get(1).getId()).isEqualTo(score9Post.getId());
+                    softly.assertThat(hotPosts.get().toList().get(2).getId()).isEqualTo(score8Post.getId());
+                    softly.assertThat(hotPosts.get().toList().get(3).getId()).isEqualTo(score6Post.getId());
+                    softly.assertThat(hotPosts.get().toList().get(4).getId()).isEqualTo(score5Post.getId());
+                }
+        );
+    }
+
+    @Test
+    void 동점일_경우_오래된_순서로_정렬된다() {
+        // given
+        Post score0Post1 = postTestSupport.builder().build();
+        Post score0Post2 = postTestSupport.builder().build();
+        Post score0Post3 = postTestSupport.builder().build();
+        Post score1Post1 = postTestSupport.builder().build();
+        Post score1Post2 = postTestSupport.builder().build();
+
+        // when
+        postReadService.findSpecificPost(score1Post1.getId(), new AnonymousMemberId());
+        postReadService.findSpecificPost(score1Post2.getId(), new AnonymousMemberId());
+
+        // then
+        Slice<Post> hotPosts = postRepository.findHotPosts(
+                HotPostPolicy.getFindPeriod(),
+                HotPostPolicy.VIEW_COUNT_WEIGHT,
+                HotPostPolicy.THUMBS_COUNT_WEIGHT,
+                page);
+
+        assertSoftly(softly -> {
+                    softly.assertThat(hotPosts.get().toList().size()).isEqualTo(5);
+                    softly.assertThat(hotPosts.get().toList().get(0).getId()).isEqualTo(score1Post1.getId());
+                    softly.assertThat(hotPosts.get().toList().get(1).getId()).isEqualTo(score1Post2.getId());
+                    softly.assertThat(hotPosts.get().toList().get(2).getId()).isEqualTo(score0Post1.getId());
+                    softly.assertThat(hotPosts.get().toList().get(3).getId()).isEqualTo(score0Post2.getId());
+                    softly.assertThat(hotPosts.get().toList().get(4).getId()).isEqualTo(score0Post3.getId());
                 }
         );
     }

--- a/backend/src/test/java/edonymyeon/backend/report/ReportServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/report/ReportServiceTest.java
@@ -15,9 +15,11 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
+@Transactional
 @SpringBootTest
 class ReportServiceTest {
 

--- a/backend/src/test/java/edonymyeon/backend/support/ThumbsUpPostTestSupport.java
+++ b/backend/src/test/java/edonymyeon/backend/support/ThumbsUpPostTestSupport.java
@@ -1,0 +1,59 @@
+package edonymyeon.backend.support;
+
+import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.post.domain.Post;
+import edonymyeon.backend.thumbs.domain.Thumbs;
+import edonymyeon.backend.thumbs.domain.ThumbsType;
+import edonymyeon.backend.thumbs.repository.ThumbsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class ThumbsUpPostTestSupport {
+
+    private final ThumbsRepository thumbsRepository;
+
+    private final PostTestSupport postTestSupport;
+
+    private final MemberTestSupport memberTestSupport;
+
+    public ThumbsBuilder builder() {
+        return new ThumbsBuilder();
+    }
+
+    public final class ThumbsBuilder {
+
+        private Post post;
+
+        private Member member;
+
+        private ThumbsType thumbsType;
+
+        public ThumbsBuilder post(final Post post) {
+            this.post = post;
+            return this;
+        }
+
+        public ThumbsBuilder member(final Member member) {
+            this.member = member;
+            return this;
+        }
+
+        public ThumbsBuilder thumbsType(final ThumbsType thumbsType) {
+            this.thumbsType = thumbsType;
+            return this;
+        }
+
+        public Thumbs build() {
+            return thumbsRepository.save(
+                    new Thumbs(
+                            post == null ? postTestSupport.builder().build() : post,
+                            member == null ? memberTestSupport.builder().build() : member,
+                            thumbsType == null ? ThumbsType.UP : thumbsType
+                    )
+            );
+        }
+    }
+
+}


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #225 

## 📝 작업 요약

핫게시글 정책에 따라 핫게시글을 구해온다 

## 🔎 작업 상세 설명

<img width="585" alt="image" src="https://github.com/woowacourse-teams/2023-edonymyeon/assets/103317169/1d8a8cac-cb0b-41d3-abe1-8494f250e4d1">

핫 게시글에 대한 기능구현중 가장 첫번째 기능인 
정책에 따라서 핫 게시글을 조회해오는 부분 입니다.

지금은 요청을 보내면 바로 핫게시글을 구해서 응답하는 식으로 구현했지만
캐싱과 스케줄러를 이용하여 30분마다 구하여 캐싱하는 방법으로 바꿀 예정입니다 !
지금은 정책에 따라 핫 게시글을 구하는 로직을 위주로 봐주세여 ><

현재 핫 게시글 정책은
- 최근 7일 이내의 글
- 좋아요 * 3
- 조회수 * 1

인데요 이를 어떻게 관리하면 좋을지 고민하다가...
일단는 상수들만 모아놓은 HotPostPolicy클래스를 만들어 가독성이 나아지도록 만들었는데용!
더 좋은 방법이 있다면 공유 부탁드림미다.... (또 현재 도메인 패키지에 넣어두었는데 이부분도 화긴점여..)

또 핫 게시글을 조회하는 개수 또한 정책에 따라 자주 바뀔 수 있다고 판단되어 전체 게시글 조회와 비슷하게
size와 page를 쿼리 파라미터로 클라이언트로부터 받도록 하였습니다 !
핫 게시글의 기본 사항들을 전체 게시글 조회랑은 조금 달라서 @HotSizing 이라는 어노테이션을 새로 만들었습니당 ㅎㅅㅎ
