### PR TITLE
fix: 키보드가 EditText를 가리는 버그 수정

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,9 +25,11 @@
 
         <activity
             android:name="com.app.edonymyeon.presentation.ui.login.LoginActivity"
+            android:windowSoftInputMode="adjustResize"
             android:exported="true">
         </activity>
         <activity android:name="com.app.edonymyeon.presentation.ui.signup.SignUpActivity"
+            android:windowSoftInputMode="adjustResize"
             android:exported="true"/>
         <activity
             android:name="com.app.edonymyeon.presentation.ui.postdetail.PostDetailActivity"


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #233 

## 📝 작업 요약

EditText가 보이게 수정하였습니다.

## 🔎 작업 상세 설명

manifest 설정으로 키보드 위로 밀리게 수정했어요!

## 🌟 리뷰 요구 사항
테스트만 해봐도 될 것 같습니다
