### PR TITLE
feat: 핫게시글 정보를 캐싱할때 expire 기간을 두어서 30분마다 캐시가 비워지도록 한다

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/cache/application/BooleanTemplate.java
+++ b/backend/src/main/java/edonymyeon/backend/cache/application/BooleanTemplate.java
@@ -5,6 +5,8 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.stereotype.Component;
 
+import java.util.concurrent.TimeUnit;
+
 @RequiredArgsConstructor
 @Component
 public class BooleanTemplate {
@@ -26,6 +28,10 @@ public class BooleanTemplate {
         redisTemplate.delete(key);
         redisTemplate.opsForValue()
                 .append(key, String.valueOf(value));
+    }
+
+    public void setExpire(String key, int expiredSeconds) {
+        redisTemplate.expire(key, expiredSeconds, TimeUnit.SECONDS);
     }
 
     public void delete(String key) {

--- a/backend/src/main/java/edonymyeon/backend/cache/application/LongTemplate.java
+++ b/backend/src/main/java/edonymyeon/backend/cache/application/LongTemplate.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @RequiredArgsConstructor
 @Component
@@ -24,9 +25,13 @@ public class LongTemplate {
         return len == 0 ? new ArrayList<>() : redisTemplate.opsForList().range(key, 0, len - 1);
     }
 
-    public void save(String postIdsKey, List<Long> hotPostIds) {
-        redisTemplate.delete(postIdsKey);
-        redisTemplate.opsForList().leftPushAll(postIdsKey, hotPostIds);
+    public void save(String key, List<Long> hotPostIds) {
+        redisTemplate.delete(key);
+        redisTemplate.opsForList().leftPushAll(key, hotPostIds);
+    }
+
+    public void setExpire(String key, int expiredSeconds) {
+        redisTemplate.expire(key, expiredSeconds, TimeUnit.SECONDS);
     }
 
     public void delete(String postIdsKey) {

--- a/backend/src/main/java/edonymyeon/backend/cache/application/PostCachingService.java
+++ b/backend/src/main/java/edonymyeon/backend/cache/application/PostCachingService.java
@@ -51,7 +51,9 @@ public class PostCachingService {
                 .toList();
 
         longTemplate.save(postIdsKey, hotPostIds);
+        longTemplate.setExpire(postIdsKey, hotPostPolicy.getExpiredSeconds());
         booleanTemplate.save(isLastKey, hotPost.isLast());
+        booleanTemplate.setExpire(isLastKey, hotPostPolicy.getExpiredSeconds());
     }
 
     private boolean isEmpty(Slice<Post> hotPost) {

--- a/backend/src/main/java/edonymyeon/backend/cache/util/CacheKeyStrategy.java
+++ b/backend/src/main/java/edonymyeon/backend/cache/util/CacheKeyStrategy.java
@@ -5,4 +5,6 @@ public interface CacheKeyStrategy {
     String getPostIdsCacheKey(final Integer size, final Integer page);
 
     String getLastCacheKey(final Integer size, final Integer page);
+
+    int getExpiredSeconds();
 }

--- a/backend/src/main/java/edonymyeon/backend/cache/util/HotPostCachePolicy.java
+++ b/backend/src/main/java/edonymyeon/backend/cache/util/HotPostCachePolicy.java
@@ -17,4 +17,8 @@ public class HotPostCachePolicy {
     public String getLastCacheKey(HotFindingCondition hotFindingCondition){
         return cacheKeyStrategy.getLastCacheKey(hotFindingCondition.getSize(), hotFindingCondition.getPage());
     }
+
+    public int getExpiredSeconds() {
+        return cacheKeyStrategy.getExpiredSeconds();
+    }
 }

--- a/backend/src/main/java/edonymyeon/backend/cache/util/ProductCacheKeyStrategy.java
+++ b/backend/src/main/java/edonymyeon/backend/cache/util/ProductCacheKeyStrategy.java
@@ -3,19 +3,28 @@ package edonymyeon.backend.cache.util;
 import org.springframework.stereotype.Component;
 
 @Component
-public class ProductCacheKeyStrategy implements CacheKeyStrategy{
+public class ProductCacheKeyStrategy implements CacheKeyStrategy {
 
     private static final String POST_IDS_CACHE_KEY = "HOT-POST:SIZE=%s_PAGE=%s";
 
     private static final String IS_LAST_CACHE_KEY = "HOT-POST-LAST:SIZE=%s_PAGE=%s";
 
+    private static final int EXPIRED_MINUTE = 30;
+
+    private static final int SECONDS_PER_MINUTE = 60;
+
     @Override
-    public String getPostIdsCacheKey(final Integer size, final Integer page){
+    public String getPostIdsCacheKey(final Integer size, final Integer page) {
         return String.format(POST_IDS_CACHE_KEY, size, page);
     }
 
     @Override
-    public String getLastCacheKey(final Integer size, final Integer page){
+    public String getLastCacheKey(final Integer size, final Integer page) {
         return String.format(IS_LAST_CACHE_KEY, size, page);
+    }
+
+    @Override
+    public int getExpiredSeconds() {
+        return EXPIRED_MINUTE * SECONDS_PER_MINUTE;
     }
 }

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostServiceHotPostsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostServiceHotPostsTest.java
@@ -84,6 +84,24 @@ public class PostServiceHotPostsTest {
     }
 
     @Test
+    void 시간이_지나면_키가_만료되는지_확인한다() throws InterruptedException {
+        // given
+        postTestSupport.builder().build();
+        postTestSupport.builder().build();
+
+        // when
+        postReadService.findHotPosts(findingCondition);
+        Thread.sleep(6000);
+
+        // then
+        assertSoftly(softly -> {
+                    softly.assertThat(longTemplate.hasCache(hotPostCachePolicy.getLastCacheKey(findingCondition))).isFalse();
+                    softly.assertThat(booleanTemplate.hasCache(hotPostCachePolicy.getLastCacheKey(findingCondition))).isFalse();
+                }
+        );
+    }
+
+    @Test
     void 최근_글이_없으면_캐싱에_저장하지_않고_빈리스트가_조회된다() {
         var hotPosts = postReadService.findHotPosts(findingCondition).getContent();
 

--- a/backend/src/test/java/edonymyeon/backend/post/application/TestCacheKeyStrategy.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/TestCacheKeyStrategy.java
@@ -8,6 +8,8 @@ public class TestCacheKeyStrategy implements CacheKeyStrategy {
 
     private static final String IS_LAST_CACHE_KEY = "TEST-HOT-POST-LAST:SIZE=%s_PAGE=%s";
 
+    private static final int EXPIRED_SECONDS = 5;
+
     @Override
     public String getPostIdsCacheKey(final Integer size, final Integer page){
         return String.format(POST_IDS_CACHE_KEY, size, page);
@@ -16,5 +18,10 @@ public class TestCacheKeyStrategy implements CacheKeyStrategy {
     @Override
     public String getLastCacheKey(final Integer size, final Integer page){
         return String.format(IS_LAST_CACHE_KEY, size, page);
+    }
+
+    @Override
+    public int getExpiredSeconds() {
+        return EXPIRED_SECONDS;
     }
 }


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #289 

## 📝 작업 요약

기존에 스프링 스케줄러로 캐싱을 비우려 하였으나 스프링 스케줄러는 멀티 스레드 환경에서 여러번 동작할 수 있다는 것을 알았습니다 ! 
레디스 캐싱값은 여러번 비워질 필요가 없었기 때문에 스케줄러로 진행하지 않았습니다 

대신 캐싱값을 저장할때 유효 기간을 두어 시간이 지남에 따라 자동으로 소멸 되도록 만들었습니다 !
큰 변경은 없으니 간단하게 확인 부탁 드려용 ㅎㅎ
