### PR TITLE
refactor: 게시글 삭제시 on delete cascade 대신 레포지토리를 통해 소비내역을 삭제하도록 수정

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/consumption/application/PostConsumptionServiceImpl.java
+++ b/backend/src/main/java/edonymyeon/backend/consumption/application/PostConsumptionServiceImpl.java
@@ -7,12 +7,15 @@ import edonymyeon.backend.consumption.domain.Consumption;
 import edonymyeon.backend.consumption.repository.ConsumptionRepository;
 import edonymyeon.backend.post.application.PostConsumptionService;
 import edonymyeon.backend.post.application.dto.response.PostConsumptionResponse;
+import edonymyeon.backend.thumbs.application.event.PostDeletionEvent;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -54,8 +57,9 @@ public class PostConsumptionServiceImpl implements PostConsumptionService {
         );
     }
 
-    @Override
-    public void deleteConsumptionByPostId(final long postId) {
-        consumptionRepository.deleteByPostId(postId);
+    @Transactional
+    @TransactionalEventListener(classes = {PostDeletionEvent.class}, phase = TransactionPhase.BEFORE_COMMIT)
+    public void deleteConsumptionByPostId(final PostDeletionEvent postDeletionEvent) {
+        consumptionRepository.deleteByPostId(postDeletionEvent.postId());
     }
 }

--- a/backend/src/main/java/edonymyeon/backend/consumption/application/PostConsumptionServiceImpl.java
+++ b/backend/src/main/java/edonymyeon/backend/consumption/application/PostConsumptionServiceImpl.java
@@ -53,4 +53,9 @@ public class PostConsumptionServiceImpl implements PostConsumptionService {
                 consumption.getConsumptionMonth()
         );
     }
+
+    @Override
+    public void deleteConsumptionByPostId(final long postId) {
+        consumptionRepository.deleteByPostId(postId);
+    }
 }

--- a/backend/src/main/java/edonymyeon/backend/consumption/domain/Consumption.java
+++ b/backend/src/main/java/edonymyeon/backend/consumption/domain/Consumption.java
@@ -47,7 +47,6 @@ public class Consumption extends TemporalRecord {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn
-    @OnDelete(action = OnDeleteAction.CASCADE) // post가 삭제될때 연관된 소비내역도 삭제될 수 있도록 한다.
     private Post post;
 
     @Enumerated(value = EnumType.STRING)

--- a/backend/src/main/java/edonymyeon/backend/consumption/repository/ConsumptionRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/consumption/repository/ConsumptionRepository.java
@@ -27,4 +27,6 @@ public interface ConsumptionRepository extends JpaRepository<Consumption, Long> 
 
     @Query("SELECT c FROM Consumption as c WHERE c.post.id IN (:postIds)")
     List<Consumption> findAllByPostIds(@Param("postIds") List<Long> postIds);
+
+    void deleteByPostId(final Long postId);
 }

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostConsumptionService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostConsumptionService.java
@@ -7,6 +7,4 @@ import java.util.Map;
 public interface PostConsumptionService {
 
     Map<Long, PostConsumptionResponse> findConsumptionsByPostIds(List<Long> postIds);
-
-    void deleteConsumptionByPostId(long postId);
 }

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostConsumptionService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostConsumptionService.java
@@ -7,4 +7,6 @@ import java.util.Map;
 public interface PostConsumptionService {
 
     Map<Long, PostConsumptionResponse> findConsumptionsByPostIds(List<Long> postIds);
+
+    void deleteConsumptionByPostId(long postId);
 }

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
@@ -18,11 +18,13 @@ import edonymyeon.backend.post.application.dto.PostRequest;
 import edonymyeon.backend.post.application.dto.PostResponse;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;
+import edonymyeon.backend.thumbs.application.event.PostDeletionEvent;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -41,7 +43,7 @@ public class PostService {
 
     private final PostThumbsService thumbsService;
 
-    private final PostConsumptionService postConsumptionService;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     private final Domain domain;
 
@@ -94,7 +96,7 @@ public class PostService {
 
         final List<PostImageInfo> postImageInfos = post.getPostImageInfos();
         final ArrayList<PostImageInfo> copyOfPostImageInfos = new ArrayList<>(postImageInfos);
-        postConsumptionService.deleteConsumptionByPostId(postId);
+        applicationEventPublisher.publishEvent(new PostDeletionEvent(post.getId()));
         thumbsService.deleteAllThumbsInPost(postId);
         postImageInfoRepository.deleteAllByPostId(postId);
         postRepository.deleteById(postId);

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
@@ -41,6 +41,8 @@ public class PostService {
 
     private final PostThumbsService thumbsService;
 
+    private final PostConsumptionService postConsumptionService;
+
     private final Domain domain;
 
     @Transactional
@@ -92,6 +94,7 @@ public class PostService {
 
         final List<PostImageInfo> postImageInfos = post.getPostImageInfos();
         final ArrayList<PostImageInfo> copyOfPostImageInfos = new ArrayList<>(postImageInfos);
+        postConsumptionService.deleteConsumptionByPostId(postId);
         thumbsService.deleteAllThumbsInPost(postId);
         postImageInfoRepository.deleteAllByPostId(postId);
         postRepository.deleteById(postId);

--- a/backend/src/main/java/edonymyeon/backend/thumbs/application/event/PostDeletionEvent.java
+++ b/backend/src/main/java/edonymyeon/backend/thumbs/application/event/PostDeletionEvent.java
@@ -1,0 +1,5 @@
+package edonymyeon.backend.thumbs.application.event;
+
+public record PostDeletionEvent(Long postId) {
+
+}


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #293 

## 📝 작업 요약

게시글 삭제시 on delete cascade 대신 레포지토리를 통해 소비내역을 삭제하도록 수정하였습니다.

(merge가 되면) 이후 데이터베이스에 직접 접속하여 다음 쿼리로 포린키 이름을 조회 후,
```
select * from information_schema.table_constraints where table_name = 'consumption';
```
다음 쿼리를 실행할 예정입니다.
```
alter table consumption drop foreign key 포린키이름;
alter table consumption add constraint foreign key (post_id) references post (id);
```

