### PR TITLE
Refactor/#295_구매 확정 다이얼로그에 원래 금액이 먼저 보이도록 수정

### DIFF
--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/mypost/MyPostActivity.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/mypost/MyPostActivity.kt
@@ -8,7 +8,9 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.RecyclerView
 import app.edonymyeon.databinding.ActivityMyPostBinding
+import com.app.edonymyeon.data.datasource.post.PostRemoteDataSource
 import com.app.edonymyeon.data.datasource.profile.ProfileRemoteDataSource
+import com.app.edonymyeon.data.repository.PostRepositoryImpl
 import com.app.edonymyeon.data.repository.ProfileRepositoryImpl
 import com.app.edonymyeon.presentation.ui.mypost.adapter.MyPostAdapter
 import com.app.edonymyeon.presentation.ui.mypost.dialog.ConsumptionDialog
@@ -28,7 +30,10 @@ class MyPostActivity : AppCompatActivity(), MyPostClickListener {
     private lateinit var dialog: ConsumptionDialog
 
     private val viewModel: MyPostViewModel by viewModels {
-        MyPostViewModelFactory(ProfileRepositoryImpl(ProfileRemoteDataSource()))
+        MyPostViewModelFactory(
+            ProfileRepositoryImpl(ProfileRemoteDataSource()),
+            PostRepositoryImpl(PostRemoteDataSource()),
+        )
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/mypost/MyPostViewModel.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/mypost/MyPostViewModel.kt
@@ -11,12 +11,15 @@ import com.app.edonymyeon.presentation.uimodel.MyPostUiModel
 import com.domain.edonymyeon.model.Date
 import com.domain.edonymyeon.model.MonthRange
 import com.domain.edonymyeon.model.Page
+import com.domain.edonymyeon.model.Post
+import com.domain.edonymyeon.repository.PostRepository
 import com.domain.edonymyeon.repository.ProfileRepository
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
 import java.time.YearMonth
 
-class MyPostViewModel(val repository: ProfileRepository) : ViewModel() {
+class MyPostViewModel(val repository: ProfileRepository, val postRepository: PostRepository) :
+    ViewModel() {
 
     private var currentPage = Page()
     private var isLastPage = false
@@ -130,6 +133,16 @@ class MyPostViewModel(val repository: ProfileRepository) : ViewModel() {
                 post.copy(consumption = consumption)
             } else {
                 post
+            }
+        }
+    }
+
+    fun getPostPrice(id: Long) {
+        viewModelScope.launch {
+            postRepository.getPostDetail(id).onSuccess {
+                _price.value = (it as Post).price.toString()
+            }.onFailure {
+                it as CustomThrowable
             }
         }
     }

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/mypost/MyPostViewModelFactory.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/mypost/MyPostViewModelFactory.kt
@@ -2,11 +2,12 @@ package com.app.edonymyeon.presentation.ui.mypost
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.domain.edonymyeon.repository.PostRepository
 import com.domain.edonymyeon.repository.ProfileRepository
 
-class MyPostViewModelFactory(private val repository: ProfileRepository) :
+class MyPostViewModelFactory(private val profileRepository: ProfileRepository, private val postRepository: PostRepository) :
     ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        return MyPostViewModel(repository) as T
+        return MyPostViewModel(profileRepository, postRepository) as T
     }
 }

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/mypost/dialog/ConsumptionDialog.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/mypost/dialog/ConsumptionDialog.kt
@@ -34,10 +34,10 @@ class ConsumptionDialog(
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
         initBinding()
-        initObserve()
+        setObserver()
         setNumberPicker()
         loadPrice()
-        initListener()
+        setListener()
     }
 
     private fun initBinding() {
@@ -46,7 +46,7 @@ class ConsumptionDialog(
         binding.lifecycleOwner = this
     }
 
-    private fun initObserve() {
+    private fun setObserver() {
         viewModel.price.observe(this) { price ->
             runCatching { if (price != BLANK) price?.toInt() ?: 0 }.onFailure {
                 binding.root.makeSnackbar(this.getString(R.string.dialog_input_price_error_message))
@@ -68,7 +68,7 @@ class ConsumptionDialog(
         viewModel.getPostPrice(id)
     }
 
-    private fun initListener() {
+    private fun setListener() {
         binding.btnDialogCancel.setOnClickListener {
             viewModel.setPurchasePrice(BLANK)
             dismiss()

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/mypost/dialog/ConsumptionDialog.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/mypost/dialog/ConsumptionDialog.kt
@@ -36,6 +36,7 @@ class ConsumptionDialog(
         initBinding()
         initObserve()
         setNumberPicker()
+        loadPrice()
         initListener()
     }
 
@@ -52,6 +53,19 @@ class ConsumptionDialog(
                 viewModel.setPurchasePrice(BLANK)
             }
         }
+    }
+
+    private fun setNumberPicker() {
+        viewModel.getYearMonth(id)
+        val minYear = viewModel.yearMonth.value?.keys?.min() ?: 0
+        val maxYear = viewModel.yearMonth.value?.keys?.max() ?: 0
+
+        updateYearNumberPicker(minYear, maxYear)
+        updateMonthNumberPicker(minYear)
+    }
+
+    private fun loadPrice() {
+        viewModel.getPostPrice(id)
     }
 
     private fun initListener() {
@@ -78,15 +92,6 @@ class ConsumptionDialog(
         binding.npYear.setOnValueChangedListener { _, _, newVal ->
             updateMonthNumberPicker(newVal)
         }
-    }
-
-    private fun setNumberPicker() {
-        viewModel.getYearMonth(id)
-        val minYear = viewModel.yearMonth.value?.keys?.min() ?: 0
-        val maxYear = viewModel.yearMonth.value?.keys?.max() ?: 0
-
-        updateYearNumberPicker(minYear, maxYear)
-        updateMonthNumberPicker(minYear)
     }
 
     private fun updateYearNumberPicker(minYear: Int, maxYear: Int) {

--- a/android/app/src/test/java/com/app/edonymyeon/presentation/ui/mypost/MyPostViewModelTest.kt
+++ b/android/app/src/test/java/com/app/edonymyeon/presentation/ui/mypost/MyPostViewModelTest.kt
@@ -5,6 +5,7 @@ import com.app.edonymyeon.mapper.toUiModel
 import com.domain.edonymyeon.model.Consumption
 import com.domain.edonymyeon.model.MyPost
 import com.domain.edonymyeon.model.MyPosts
+import com.domain.edonymyeon.repository.PostRepository
 import com.domain.edonymyeon.repository.ProfileRepository
 import io.mockk.coEvery
 import io.mockk.mockk
@@ -23,6 +24,7 @@ class MyPostViewModelTest {
 
     private lateinit var viewModel: MyPostViewModel
     private lateinit var profileRepository: ProfileRepository
+    private lateinit var postRepository: PostRepository
 
     private val fakeMyPost = listOf(
         MyPost(
@@ -79,7 +81,8 @@ class MyPostViewModelTest {
     fun setUp() {
         Dispatchers.setMain(UnconfinedTestDispatcher())
         profileRepository = mockk()
-        viewModel = MyPostViewModel(profileRepository)
+        postRepository = mockk()
+        viewModel = MyPostViewModel(profileRepository, postRepository)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #295 

## 📝 작업 요약

구매 확정 다이얼로그에 원래 금액이 먼저 보이도록 수정

## 🔎 작업 상세 설명

원래 구매 확정 다이얼로그를 열면 금액 입력 받는 부분이 빈칸으로 되어 있는데 자신이 썼던 글에 저장된 금액이 보여지는게 좋을 것 같아서
수정하였습니다!

## 🌟 리뷰 요구 사항

고친 부분이 많지 않아서 리뷰는 오래 걸리지 않을 것 같아요!😄
