### PR TITLE
refactor: 로그파일 저장 경로 수정

### DIFF
--- a/backend/src/main/resources/console-error-appender.xml
+++ b/backend/src/main/resources/console-error-appender.xml
@@ -25,7 +25,7 @@
         </encoder>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>error-history.log.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <fileNamePattern>./logs/history/error-history.log.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <maxFileSize>50MB</maxFileSize>
                 <!-- 한 로그 파일이 50MB 차면 위 fileNamePattern으로 분리해 저장한다 -->

--- a/backend/src/main/resources/console-info-appender.xml
+++ b/backend/src/main/resources/console-info-appender.xml
@@ -25,7 +25,7 @@
         </encoder>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>info-history.log.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <fileNamePattern>./logs/history/info-history.log.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <maxFileSize>50MB</maxFileSize>
                 <!-- 한 로그 파일이 50MB 차면 위 fileNamePattern으로 분리해 저장한다 -->

--- a/backend/src/main/resources/console-warn-appender.xml
+++ b/backend/src/main/resources/console-warn-appender.xml
@@ -24,7 +24,7 @@
         </encoder>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>warn-history.log.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <fileNamePattern>./logs/history/warn-history.log.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <maxFileSize>50MB</maxFileSize>
                 <!-- 한 로그 파일이 50MB 차면 위 fileNamePattern으로 분리해 저장한다 -->


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #305 

## 📝 작업 요약

기존에 backend 하위에 생성되었던 로그 히스토리들이 킹받아서
로그 히스토리 파일들의 저장 경로를 logs 폴더 하위로 수정하였습니다.

<img width="354" alt="스크린샷 2023-08-19 오후 10 09 49" src="https://github.com/woowacourse-teams/2023-edonymyeon/assets/62106852/8137c5ae-3432-4f85-93ac-e660e3c266e0">

