### PR TITLE
Fix/#311 캐싱된 게시글이 삭제된 경우 처리

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/cache/application/dto/CachedPostResponse.java
+++ b/backend/src/main/java/edonymyeon/backend/cache/application/dto/CachedPostResponse.java
@@ -3,4 +3,8 @@ package edonymyeon.backend.cache.application.dto;
 import java.util.List;
 
 public record CachedPostResponse(List<Long> postIds, boolean isLast) {
+
+    public int size(){
+        return postIds.size();
+    }
 }


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #311 

## 📝 작업 요약

현재 캐싱된 핫게시글이 5개일 때 핫 게시글을 삭제하면, 4개만 조회된다!
캐싱된 개수와 실제 조회개수가 달라지면 캐싱 값을 업데이트 하도록 한다
