### PR TITLE
fix: 카카오 회원의 탈퇴 후, 로그인 시 로직 처리 추가

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
+++ b/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
@@ -34,11 +34,11 @@ public class AuthService {
     private final ApplicationEventPublisher publisher;
     private final MemberRepository memberRepository;
 
-    public MemberId findMember(final LoginRequest loginRequest) {
-        return findMember(loginRequest.email(), loginRequest.password());
+    public MemberId login(final LoginRequest loginRequest) {
+        return login(loginRequest.email(), loginRequest.password());
     }
 
-    public MemberId findMember(final String email, final String password) {
+    public MemberId login(final String email, final String password) {
         final Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new EdonymyeonException(MEMBER_EMAIL_NOT_FOUND));
         member.checkPassword(password);
@@ -66,10 +66,13 @@ public class AuthService {
 
     //todo session으로
     @Transactional
-    public MemberResponse findMemberByKakao(final KakaoLoginResponse kakaoLoginResponse) {
+    public MemberResponse loginByKakao(final KakaoLoginResponse kakaoLoginResponse) {
         final SocialInfo socialInfo = SocialInfo.of(SocialType.KAKAO, kakaoLoginResponse.id());
         final Member member = memberRepository.findBySocialInfo(socialInfo)
                 .orElseGet(() -> joinSocialMember(socialInfo));
+        if (member.isDeleted()) {
+            throw new EdonymyeonException(MEMBER_IS_DELETED);
+        }
         return new MemberResponse(member.getEmail(), member.getPassword());
     }
 

--- a/backend/src/main/java/edonymyeon/backend/auth/ui/AuthController.java
+++ b/backend/src/main/java/edonymyeon/backend/auth/ui/AuthController.java
@@ -31,7 +31,7 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<Void> login(@RequestBody LoginRequest loginRequest) {
-        authService.findMember(loginRequest);
+        authService.login(loginRequest);
         final String basicToken = tokenGenerator.getBasicToken(loginRequest.email(), loginRequest.password());
         return ResponseEntity.ok()
                 .header(HttpHeaders.AUTHORIZATION, basicToken)
@@ -42,7 +42,7 @@ public class AuthController {
     public ResponseEntity<Void> loginWithKakao(@RequestBody KakaoLoginRequest loginRequest) {
         final KakaoLoginResponse kakaoLoginResponse = kakaoAuthResponseProvider.request(loginRequest);
 
-        final MemberResponse memberResponse = authService.findMemberByKakao(kakaoLoginResponse);
+        final MemberResponse memberResponse = authService.loginByKakao(kakaoLoginResponse);
         final String basicToken = tokenGenerator.getBasicToken(memberResponse.email(), memberResponse.password());
         return ResponseEntity.ok()
                 .header(HttpHeaders.AUTHORIZATION, basicToken)

--- a/backend/src/main/java/edonymyeon/backend/auth/ui/argumentresolver/AuthArgumentResolver.java
+++ b/backend/src/main/java/edonymyeon/backend/auth/ui/argumentresolver/AuthArgumentResolver.java
@@ -53,7 +53,7 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
             throw new EdonymyeonException(AUTHORIZATION_EMPTY);
         }
 
-        return authService.findMember(email, password);
+        return authService.login(email, password);
     }
 
     private static String[] getCredentials(final String authorization) {

--- a/backend/src/test/java/edonymyeon/backend/auth/application/AuthDeleteServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/auth/application/AuthDeleteServiceTest.java
@@ -45,7 +45,7 @@ public class AuthDeleteServiceTest {
         when(memberRepository.findByEmail(member.getEmail()))
                 .thenReturn(Optional.of(member));
 
-        assertThatThrownBy(() -> authService.findMember(member.getEmail(), member.getPassword()))
+        assertThatThrownBy(() -> authService.login(member.getEmail(), member.getPassword()))
                 .isInstanceOf(EdonymyeonException.class)
                 .hasMessage(MEMBER_IS_DELETED.getMessage());
     }

--- a/backend/src/test/java/edonymyeon/backend/auth/docs/AuthControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/auth/docs/AuthControllerDocsTest.java
@@ -56,7 +56,7 @@ public class AuthControllerDocsTest extends DocsTest {
     void 로그인_문서화() throws Exception {
         final LoginRequest request = new LoginRequest("example@example.com", "password1234!", "kj234jkn342kj");
 
-        when(authService.findMember(request)).thenReturn(any());
+        when(authService.login(request)).thenReturn(any());
 
         final MockHttpServletRequestBuilder 로그인_요청 = post("/login")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -90,7 +90,7 @@ public class AuthControllerDocsTest extends DocsTest {
         final MemberResponse memberResponse = new MemberResponse("example@email.com", "password123!");
 
         when(kakaoAuthResponseProvider.request(kakaoLoginRequest)).thenReturn(kakaoLoginResponse);
-        when(authService.findMemberByKakao(kakaoLoginResponse)).thenReturn(memberResponse);
+        when(authService.loginByKakao(kakaoLoginResponse)).thenReturn(memberResponse);
 
         final MockHttpServletRequestBuilder 로그인_요청 = post("/auth/kakao/login")
                 .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #325 

## 📝 작업 요약

- 카카오톡 로그인 한 유저가 회원 탈퇴 후, 로그인 시 로직 추가
- 로그인 시 회원 찾는 메서드 명확하게 수정
