### PR TITLE
Refactor/#342 코드 최적화

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
+++ b/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
@@ -91,9 +91,13 @@ public class Member extends TemporalRecord {
     }
 
     public static Member from(final SocialInfo socialInfo) {
-        return new Member(UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                "#" + socialInfo.getSocialType().name() + UUID.randomUUID(),
+        final String nicknamePrefix = "#" + socialInfo.getSocialType().name();
+        return new Member(UUID.randomUUID().toString().substring(0, MAX_EMAIL_LENGTH),
+                "H!" + UUID.randomUUID().toString()
+                        .substring(0, MAX_PASSWORD_LENGTH)
+                        .replaceAll("-", ""),
+                nicknamePrefix + UUID.randomUUID().toString()
+                        .substring(0, MAX_NICKNAME_LENGTH - nicknamePrefix.length()),
                 socialInfo);
     }
 

--- a/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
+++ b/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
@@ -97,10 +97,6 @@ public class Member extends TemporalRecord {
         this.deleted = deleted;
     }
 
-    public Member(final Long id) {
-        this.id = id;
-    }
-
     public Member(final String email, final String password, final String nickname, final SocialInfo socialInfo) {
         this.email = email;
         this.password = password;
@@ -193,5 +189,9 @@ public class Member extends TemporalRecord {
 
     private boolean isNewDevice(final String deviceToken) {
         return this.devices.stream().noneMatch(device -> device.isDeviceTokenEqualTo(deviceToken));
+    }
+
+    public boolean hasId(final Long memberId) {
+        return Objects.equals(this.id, memberId);
     }
 }

--- a/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
+++ b/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
@@ -82,21 +82,6 @@ public class Member extends TemporalRecord {
                 .toList();
     }
 
-    public Member(final Long id, final String email, final String password, final String nickname,
-                  final SocialInfo socialInfo,
-                  final ProfileImageInfo profileImageInfo, final List<String> deviceTokens, final boolean deleted) {
-        this.id = id;
-        this.email = email;
-        this.password = password;
-        this.nickname = nickname;
-        this.socialInfo = socialInfo;
-        this.profileImageInfo = profileImageInfo;
-        this.devices = deviceTokens.stream()
-                .map(token -> new Device(token, this))
-                .toList();
-        this.deleted = deleted;
-    }
-
     public Member(final String email, final String password, final String nickname, final SocialInfo socialInfo) {
         this.email = email;
         this.password = password;

--- a/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
+++ b/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
@@ -83,6 +83,7 @@ public class Member extends TemporalRecord {
     }
 
     private Member(final String email, final String password, final String nickname, final SocialInfo socialInfo) {
+        validate(email, password, nickname);
         this.email = email;
         this.password = password;
         this.nickname = nickname;

--- a/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
+++ b/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
@@ -82,7 +82,7 @@ public class Member extends TemporalRecord {
                 .toList();
     }
 
-    public Member(final String email, final String password, final String nickname, final SocialInfo socialInfo) {
+    private Member(final String email, final String password, final String nickname, final SocialInfo socialInfo) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;

--- a/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
+++ b/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
@@ -164,6 +164,10 @@ public class Post extends TemporalRecord {
         return this.member.equals(member);
     }
 
+    public boolean isSameMember(final Long memberId) {
+        return this.member.hasId(memberId);
+    }
+
     public Member getMember() {
         return member;
     }
@@ -181,8 +185,7 @@ public class Post extends TemporalRecord {
     }
 
     public void validateWriter(final Long memberId) {
-        final Member other = new Member(memberId);
-        if (!isSameMember(other)) {
+        if (!isSameMember(memberId)) {
             throw new EdonymyeonException(POST_MEMBER_NOT_SAME);
         }
     }

--- a/backend/src/test/java/edonymyeon/backend/auth/AuthIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/auth/AuthIntegrationTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import edonymyeon.backend.auth.application.KakaoAuthResponseProvider;
-import edonymyeon.backend.support.IntegrationFixture;
 import edonymyeon.backend.auth.application.dto.DuplicateCheckResponse;
 import edonymyeon.backend.auth.application.dto.JoinRequest;
 import edonymyeon.backend.auth.application.dto.KakaoLoginRequest;
@@ -60,6 +59,7 @@ public class AuthIntegrationTest extends IntegrationFixture {
         final Member member = memberTestSupport.builder()
                 .email("email@naver.com")
                 .build();
+
         final ExtractableResponse<Response> response = RestAssured
                 .given()
                 .param("target", "email")

--- a/backend/src/test/java/edonymyeon/backend/auth/application/AuthDeleteServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/auth/application/AuthDeleteServiceTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.support.IntegrationTest;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -33,7 +33,7 @@ public class AuthDeleteServiceTest {
                 .builder()
                 .id(1L)
                 .email("test@email.com")
-                .password("passwrod1234")
+                .password("passwrod1234!")
                 .nickname("null")
                 .deleted(true)
                 .build();

--- a/backend/src/test/java/edonymyeon/backend/auth/application/AuthDeleteServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/auth/application/AuthDeleteServiceTest.java
@@ -2,15 +2,11 @@ package edonymyeon.backend.auth.application;
 
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_IS_DELETED;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
 
 import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.member.repository.MemberRepository;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.support.IntegrationTest;
-import java.lang.reflect.Field;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -18,8 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.util.ReflectionUtils;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -28,22 +22,21 @@ import org.springframework.util.ReflectionUtils;
 @IntegrationTest
 public class AuthDeleteServiceTest {
 
-    @MockBean
-    private MemberRepository memberRepository;
+    private final TestMemberBuilder testMemberBuilder;
 
     @Autowired
     private AuthService authService;
 
     @Test
     void 멤버_삭제후_조회시_예외반환() {
-        final Member member = new Member("test@email.com", "passwrod1234!", "null", null, List.of());
-
-        final Field deletedField = ReflectionUtils.findField(Member.class, "deleted");
-        ReflectionUtils.makeAccessible(deletedField);
-        ReflectionUtils.setField(deletedField, member, true);
-
-        when(memberRepository.findByEmail(member.getEmail()))
-                .thenReturn(Optional.of(member));
+        final Member member = testMemberBuilder
+                .builder()
+                .id(1L)
+                .email("test@email.com")
+                .password("passwrod1234")
+                .nickname("null")
+                .deleted(true)
+                .build();
 
         assertThatThrownBy(() -> authService.login(member.getEmail(), member.getPassword()))
                 .isInstanceOf(EdonymyeonException.class)

--- a/backend/src/test/java/edonymyeon/backend/consumption/application/MemberConsumptionServiceImplTest.java
+++ b/backend/src/test/java/edonymyeon/backend/consumption/application/MemberConsumptionServiceImplTest.java
@@ -9,7 +9,7 @@ import edonymyeon.backend.consumption.repository.ConsumptionRepository;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.application.dto.YearMonthDto;
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.support.PostTestSupport;

--- a/backend/src/test/java/edonymyeon/backend/consumption/application/MemberConsumptionServiceImplTest.java
+++ b/backend/src/test/java/edonymyeon/backend/consumption/application/MemberConsumptionServiceImplTest.java
@@ -1,20 +1,20 @@
 package edonymyeon.backend.consumption.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import edonymyeon.backend.consumption.domain.Consumption;
 import edonymyeon.backend.consumption.domain.ConsumptionType;
 import edonymyeon.backend.consumption.repository.ConsumptionRepository;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.application.dto.YearMonthDto;
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.support.PostTestSupport;
+import edonymyeon.backend.support.TestMemberBuilder;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @SuppressWarnings("NonAsciiCharacters")
 @RequiredArgsConstructor
@@ -31,8 +31,7 @@ class MemberConsumptionServiceImplTest {
 
     @Test
     void 절약_확정시_게시글에_저장된_금액이_절약_금액이_된다() {
-        final Member 글쓴이 = testMemberBuilder.builder()
-                .build();
+        final Member 글쓴이 = testMemberBuilder.builder().build();
         final Post 게시글 = postTestSupport.builder()
                 .member(글쓴이)
                 .build();
@@ -56,8 +55,7 @@ class MemberConsumptionServiceImplTest {
 
     @Test
     void 구매_확정시_입력받은_금액이_구매_금액이_된다() {
-        final Member 글쓴이 = testMemberBuilder.builder()
-                .build();
+        final Member 글쓴이 = testMemberBuilder.builder().build();
         final Post 게시글 = postTestSupport.builder()
                 .member(글쓴이)
                 .build();

--- a/backend/src/test/java/edonymyeon/backend/consumption/application/MemberConsumptionServiceImplTest.java
+++ b/backend/src/test/java/edonymyeon/backend/consumption/application/MemberConsumptionServiceImplTest.java
@@ -3,15 +3,15 @@ package edonymyeon.backend.consumption.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
-import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.consumption.domain.Consumption;
 import edonymyeon.backend.consumption.domain.ConsumptionType;
 import edonymyeon.backend.consumption.repository.ConsumptionRepository;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.application.dto.YearMonthDto;
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.post.domain.Post;
-import edonymyeon.backend.support.MemberTestSupport;
+import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.support.PostTestSupport;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
@@ -25,13 +25,13 @@ class MemberConsumptionServiceImplTest {
 
     private final ConsumptionRepository consumptionRepository;
 
-    private final MemberTestSupport memberTestSupport;
+    private final TestMemberBuilder testMemberBuilder;
 
     private final PostTestSupport postTestSupport;
 
     @Test
     void 절약_확정시_게시글에_저장된_금액이_절약_금액이_된다() {
-        final Member 글쓴이 = memberTestSupport.builder()
+        final Member 글쓴이 = testMemberBuilder.builder()
                 .build();
         final Post 게시글 = postTestSupport.builder()
                 .member(글쓴이)
@@ -56,7 +56,7 @@ class MemberConsumptionServiceImplTest {
 
     @Test
     void 구매_확정시_입력받은_금액이_구매_금액이_된다() {
-        final Member 글쓴이 = memberTestSupport.builder()
+        final Member 글쓴이 = testMemberBuilder.builder()
                 .build();
         final Post 게시글 = postTestSupport.builder()
                 .member(글쓴이)

--- a/backend/src/test/java/edonymyeon/backend/consumption/docs/ConsumptionControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/consumption/docs/ConsumptionControllerDocsTest.java
@@ -15,6 +15,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.queryPar
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.support.DocsTest;
 import edonymyeon.backend.consumption.application.ConsumptionService;
 import edonymyeon.backend.consumption.application.dto.ConsumptionPriceResponse;
@@ -32,6 +33,8 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 
 @SuppressWarnings("NonAsciiCharacters")
 public class ConsumptionControllerDocsTest extends DocsTest {
+
+    private final TestMemberBuilder testMemberBuilder = new TestMemberBuilder(null);
 
     @MockBean
     private ConsumptionService consumptionService;
@@ -54,7 +57,12 @@ public class ConsumptionControllerDocsTest extends DocsTest {
 
     @Test
     void 특정기간의_소비금액을_확인한다() throws Exception {
-        final Member 회원 = new Member(1L, "email@email.com", "password123!", "nickname", null, null, List.of(), false);
+        final Member 회원 = testMemberBuilder.builder()
+                .id(1L)
+                .email("email@email.com")
+                .password("password123!")
+                .nickname("nickname")
+                .buildWithoutSaving();
         final RecentConsumptionsResponse response = new RecentConsumptionsResponse(
                 "2023-08",
                 "2023-08",

--- a/backend/src/test/java/edonymyeon/backend/consumption/docs/ConsumptionControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/consumption/docs/ConsumptionControllerDocsTest.java
@@ -15,7 +15,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.queryPar
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.support.DocsTest;
 import edonymyeon.backend.consumption.application.ConsumptionService;
 import edonymyeon.backend.consumption.application.dto.ConsumptionPriceResponse;

--- a/backend/src/test/java/edonymyeon/backend/consumption/docs/ConsumptionControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/consumption/docs/ConsumptionControllerDocsTest.java
@@ -1,5 +1,23 @@
 package edonymyeon.backend.consumption.docs;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edonymyeon.backend.consumption.application.ConsumptionService;
+import edonymyeon.backend.consumption.application.dto.ConsumptionPriceResponse;
+import edonymyeon.backend.consumption.application.dto.RecentConsumptionsResponse;
+import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.repository.MemberRepository;
+import edonymyeon.backend.support.DocsTest;
+import edonymyeon.backend.support.TestMemberBuilder;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.util.List;
+import java.util.Optional;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
@@ -13,23 +31,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import edonymyeon.backend.support.TestMemberBuilder;
-import edonymyeon.backend.support.DocsTest;
-import edonymyeon.backend.consumption.application.ConsumptionService;
-import edonymyeon.backend.consumption.application.dto.ConsumptionPriceResponse;
-import edonymyeon.backend.consumption.application.dto.RecentConsumptionsResponse;
-import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.member.repository.MemberRepository;
-import java.util.List;
-import java.util.Optional;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpHeaders;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class ConsumptionControllerDocsTest extends DocsTest {
@@ -58,10 +59,6 @@ public class ConsumptionControllerDocsTest extends DocsTest {
     @Test
     void 특정기간의_소비금액을_확인한다() throws Exception {
         final Member 회원 = testMemberBuilder.builder()
-                .id(1L)
-                .email("email@email.com")
-                .password("password123!")
-                .nickname("nickname")
                 .buildWithoutSaving();
         final RecentConsumptionsResponse response = new RecentConsumptionsResponse(
                 "2023-08",

--- a/backend/src/test/java/edonymyeon/backend/consumption/domain/ConsumptionsPerMonthTest.java
+++ b/backend/src/test/java/edonymyeon/backend/consumption/domain/ConsumptionsPerMonthTest.java
@@ -3,7 +3,7 @@ package edonymyeon.backend.consumption.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.post.domain.Post;
 import java.time.LocalDate;
 import java.util.ArrayList;

--- a/backend/src/test/java/edonymyeon/backend/consumption/domain/ConsumptionsPerMonthTest.java
+++ b/backend/src/test/java/edonymyeon/backend/consumption/domain/ConsumptionsPerMonthTest.java
@@ -1,17 +1,18 @@
 package edonymyeon.backend.consumption.domain;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.post.domain.Post;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
+import edonymyeon.backend.support.TestMemberBuilder;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -22,11 +23,7 @@ class ConsumptionsPerMonthTest {
     @Test
     void 소비내역을_달별로_분류한다() {
         final Member 회원 = testMemberBuilder.builder()
-                .email("email")
-                .password("password123!")
-                .nickname("nickname")
                 .buildWithoutSaving();
-
         final Post 게시글1 = new Post("title", "content", 1_000L, 회원);
         final Post 게시글2 = new Post("title", "content", 2_000L, 회원);
 

--- a/backend/src/test/java/edonymyeon/backend/consumption/domain/ConsumptionsPerMonthTest.java
+++ b/backend/src/test/java/edonymyeon/backend/consumption/domain/ConsumptionsPerMonthTest.java
@@ -3,6 +3,7 @@ package edonymyeon.backend.consumption.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.post.domain.Post;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -16,9 +17,16 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("NonAsciiCharacters")
 class ConsumptionsPerMonthTest {
 
+    private final TestMemberBuilder testMemberBuilder = new TestMemberBuilder(null);
+
     @Test
     void 소비내역을_달별로_분류한다() {
-        final Member 회원 = new Member("email", "password123!", "nickname", null, List.of());
+        final Member 회원 = testMemberBuilder.builder()
+                .email("email")
+                .password("password123!")
+                .nickname("nickname")
+                .buildWithoutSaving();
+
         final Post 게시글1 = new Post("title", "content", 1_000L, 회원);
         final Post 게시글2 = new Post("title", "content", 2_000L, 회원);
 
@@ -50,7 +58,6 @@ class ConsumptionsPerMonthTest {
 
     @Test
     void 소비내역이_없을_경우_구매금액의합은_0_절약금액의합도_0() {
-        final Member 회원 = new Member("email", "password123!", "nickname", null, List.of());
         List<Consumption> consumptions = new ArrayList<>();
 
         final List<ConsumptionsPerMonth> 두달_소비금액 = ConsumptionsPerMonth.of(

--- a/backend/src/test/java/edonymyeon/backend/consumption/integration/ConsumptionIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/consumption/integration/ConsumptionIntegrationTest.java
@@ -3,7 +3,6 @@ package edonymyeon.backend.consumption.integration;
 import static edonymyeon.backend.consumption.integration.steps.ConsumptionSteps.특정_기간의_소비금액을_확인한다;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import edonymyeon.backend.support.IntegrationFixture;
 import edonymyeon.backend.consumption.domain.Consumption;
 import edonymyeon.backend.consumption.domain.ConsumptionType;
 import edonymyeon.backend.global.controlleradvice.dto.ExceptionResponse;
@@ -11,6 +10,7 @@ import edonymyeon.backend.global.exception.ExceptionInformation;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.support.ConsumptionTestSupport;
+import edonymyeon.backend.support.IntegrationFixture;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.time.LocalDate;

--- a/backend/src/test/java/edonymyeon/backend/consumption/repository/ConsumptionRepositoryTest.java
+++ b/backend/src/test/java/edonymyeon/backend/consumption/repository/ConsumptionRepositoryTest.java
@@ -2,7 +2,7 @@ package edonymyeon.backend.consumption.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.consumption.domain.Consumption;
 import edonymyeon.backend.consumption.domain.ConsumptionType;

--- a/backend/src/test/java/edonymyeon/backend/consumption/repository/ConsumptionRepositoryTest.java
+++ b/backend/src/test/java/edonymyeon/backend/consumption/repository/ConsumptionRepositoryTest.java
@@ -2,13 +2,13 @@ package edonymyeon.backend.consumption.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.consumption.domain.Consumption;
 import edonymyeon.backend.consumption.domain.ConsumptionType;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.support.ConsumptionTestSupport;
-import edonymyeon.backend.support.MemberTestSupport;
 import edonymyeon.backend.support.PostTestSupport;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -24,7 +24,7 @@ class ConsumptionRepositoryTest {
 
     private final ConsumptionRepository consumptionRepository;
 
-    private final MemberTestSupport memberTestSupport;
+    private final TestMemberBuilder memberTestSupport;
 
     private final ConsumptionTestSupport consumptionTestSupport;
 

--- a/backend/src/test/java/edonymyeon/backend/image/ImageFileSizeIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/image/ImageFileSizeIntegrationTest.java
@@ -3,10 +3,10 @@ package edonymyeon.backend.image;
 import static edonymyeon.backend.global.exception.ExceptionInformation.REQUEST_FILE_SIZE_TOO_LARGE;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import edonymyeon.backend.support.IntegrationFixture;
 import edonymyeon.backend.global.controlleradvice.dto.ExceptionResponse;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.post.ImageFileCleaner;
+import edonymyeon.backend.support.IntegrationFixture;
 import io.restassured.RestAssured;
 import java.io.File;
 import org.assertj.core.api.SoftAssertions;

--- a/backend/src/test/java/edonymyeon/backend/member/docs/MemberControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/member/docs/MemberControllerDocsTest.java
@@ -23,12 +23,12 @@ import edonymyeon.backend.consumption.repository.ConsumptionRepository;
 import edonymyeon.backend.member.application.dto.request.PurchaseConfirmRequest;
 import edonymyeon.backend.member.application.dto.request.SavingConfirmRequest;
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;
 import edonymyeon.backend.support.DocsTest;
 import java.util.Base64;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -40,6 +40,8 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 
 @SuppressWarnings("NonAsciiCharacters")
 public class MemberControllerDocsTest extends DocsTest {
+
+    private final TestMemberBuilder testMemberBuilder = new TestMemberBuilder(null);
 
     @MockBean
     private MemberRepository memberRepository;
@@ -74,7 +76,12 @@ public class MemberControllerDocsTest extends DocsTest {
 
     @Test
     void 구매_확정한다() throws Exception {
-        final Member 회원 = new Member("email", "password123!", "nickname", null, List.of());
+        final Member 회원 = testMemberBuilder.builder()
+                .email("email")
+                .password("password123!")
+                .nickname("nickname")
+                .buildWithoutSaving();
+
         final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 회원);
         final Consumption 소비 = Consumption.of(게시글, SAVING, null, 2023, 7);
 
@@ -113,7 +120,11 @@ public class MemberControllerDocsTest extends DocsTest {
 
     @Test
     void 절약_확정한다() throws Exception {
-        final Member 회원 = new Member("email", "password123!", "nickname", null, List.of());
+        final Member 회원 = testMemberBuilder.builder()
+                .email("email")
+                .password("password123!")
+                .nickname("nickname")
+                .buildWithoutSaving();
         final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 회원);
         final Consumption 소비 = Consumption.of(게시글, SAVING, null, 2023, 7);
 
@@ -151,7 +162,11 @@ public class MemberControllerDocsTest extends DocsTest {
 
     @Test
     void 확정을_취소한다() throws Exception {
-        final Member 회원 = new Member("email", "password123!", "nickname", null, List.of());
+        final Member 회원 = testMemberBuilder.builder()
+                .email("email")
+                .password("password123!")
+                .nickname("nickname")
+                .buildWithoutSaving();
         final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 회원);
         final Consumption 소비 = Consumption.of(게시글, SAVING, null, 2023, 7);
 
@@ -181,8 +196,11 @@ public class MemberControllerDocsTest extends DocsTest {
 
     @Test
     void 회원_탈퇴한다() throws Exception {
-        final Member 회원 = new Member("email@email.com", "password123!", "nickname", null);
-
+        final Member 회원 = testMemberBuilder.builder()
+                .email("email")
+                .password("password123!")
+                .nickname("nickname")
+                .buildWithoutSaving();
         회원_레포지토리를_모킹한다(회원);
         when(memberRepository.findById(회원.getId())).thenReturn(Optional.of(회원));
 

--- a/backend/src/test/java/edonymyeon/backend/member/docs/MemberControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/member/docs/MemberControllerDocsTest.java
@@ -1,5 +1,27 @@
 package edonymyeon.backend.member.docs;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edonymyeon.backend.consumption.domain.Consumption;
+import edonymyeon.backend.consumption.repository.ConsumptionRepository;
+import edonymyeon.backend.member.application.dto.request.PurchaseConfirmRequest;
+import edonymyeon.backend.member.application.dto.request.SavingConfirmRequest;
+import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.repository.MemberRepository;
+import edonymyeon.backend.post.domain.Post;
+import edonymyeon.backend.post.repository.PostRepository;
+import edonymyeon.backend.support.DocsTest;
+import edonymyeon.backend.support.TestMemberBuilder;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.util.Base64;
+import java.util.Optional;
+
 import static edonymyeon.backend.consumption.domain.ConsumptionType.SAVING;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -16,27 +38,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import edonymyeon.backend.consumption.domain.Consumption;
-import edonymyeon.backend.consumption.repository.ConsumptionRepository;
-import edonymyeon.backend.member.application.dto.request.PurchaseConfirmRequest;
-import edonymyeon.backend.member.application.dto.request.SavingConfirmRequest;
-import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.support.TestMemberBuilder;
-import edonymyeon.backend.member.repository.MemberRepository;
-import edonymyeon.backend.post.domain.Post;
-import edonymyeon.backend.post.repository.PostRepository;
-import edonymyeon.backend.support.DocsTest;
-import java.util.Base64;
-import java.util.Optional;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class MemberControllerDocsTest extends DocsTest {
@@ -77,11 +78,7 @@ public class MemberControllerDocsTest extends DocsTest {
     @Test
     void 구매_확정한다() throws Exception {
         final Member 회원 = testMemberBuilder.builder()
-                .email("email")
-                .password("password123!")
-                .nickname("nickname")
                 .buildWithoutSaving();
-
         final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 회원);
         final Consumption 소비 = Consumption.of(게시글, SAVING, null, 2023, 7);
 
@@ -120,11 +117,7 @@ public class MemberControllerDocsTest extends DocsTest {
 
     @Test
     void 절약_확정한다() throws Exception {
-        final Member 회원 = testMemberBuilder.builder()
-                .email("email")
-                .password("password123!")
-                .nickname("nickname")
-                .buildWithoutSaving();
+        final Member 회원 = testMemberBuilder.builder().buildWithoutSaving();
         final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 회원);
         final Consumption 소비 = Consumption.of(게시글, SAVING, null, 2023, 7);
 
@@ -162,11 +155,7 @@ public class MemberControllerDocsTest extends DocsTest {
 
     @Test
     void 확정을_취소한다() throws Exception {
-        final Member 회원 = testMemberBuilder.builder()
-                .email("email")
-                .password("password123!")
-                .nickname("nickname")
-                .buildWithoutSaving();
+        final Member 회원 = testMemberBuilder.builder().buildWithoutSaving();
         final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 회원);
         final Consumption 소비 = Consumption.of(게시글, SAVING, null, 2023, 7);
 
@@ -196,11 +185,7 @@ public class MemberControllerDocsTest extends DocsTest {
 
     @Test
     void 회원_탈퇴한다() throws Exception {
-        final Member 회원 = testMemberBuilder.builder()
-                .email("email")
-                .password("password123!")
-                .nickname("nickname")
-                .buildWithoutSaving();
+        final Member 회원 = testMemberBuilder.builder().buildWithoutSaving();
         회원_레포지토리를_모킹한다(회원);
         when(memberRepository.findById(회원.getId())).thenReturn(Optional.of(회원));
 

--- a/backend/src/test/java/edonymyeon/backend/member/docs/MemberControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/member/docs/MemberControllerDocsTest.java
@@ -23,7 +23,7 @@ import edonymyeon.backend.consumption.repository.ConsumptionRepository;
 import edonymyeon.backend.member.application.dto.request.PurchaseConfirmRequest;
 import edonymyeon.backend.member.application.dto.request.SavingConfirmRequest;
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;

--- a/backend/src/test/java/edonymyeon/backend/member/domain/TestMemberBuilder.java
+++ b/backend/src/test/java/edonymyeon/backend/member/domain/TestMemberBuilder.java
@@ -3,8 +3,8 @@ package edonymyeon.backend.member.domain;
 import edonymyeon.backend.image.profileimage.domain.ProfileImageInfo;
 import edonymyeon.backend.member.repository.MemberRepository;
 import java.lang.reflect.Field;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ReflectionUtils;
@@ -116,7 +116,7 @@ public class TestMemberBuilder {
         private void setField(final Member member, final String fieldName, final Object value, final Object orElse) {
             final Field field = ReflectionUtils.findField(Member.class, fieldName);
             ReflectionUtils.makeAccessible(field);
-            if (value != null) {
+            if (Objects.nonNull(value)) {
                 ReflectionUtils.setField(field, member, value);
                 return;
             }

--- a/backend/src/test/java/edonymyeon/backend/member/domain/TestMemberBuilder.java
+++ b/backend/src/test/java/edonymyeon/backend/member/domain/TestMemberBuilder.java
@@ -13,7 +13,7 @@ import org.springframework.util.ReflectionUtils;
 @Component
 public class TestMemberBuilder {
 
-    private static final String DEFAULT_EMAIL = "email";
+    private static final String DEFAULT_EMAIL = "email@edonymyeon.com";
 
     private static final String DEFAULT_PASSWORD = "password123!";
 

--- a/backend/src/test/java/edonymyeon/backend/member/domain/TestMemberBuilder.java
+++ b/backend/src/test/java/edonymyeon/backend/member/domain/TestMemberBuilder.java
@@ -100,6 +100,19 @@ public class TestMemberBuilder {
             return memberRepository.save(member);
         }
 
+        public Member buildWithoutSaving() {
+            final Member member = new Member();
+            setField(member, "id", this.id, null);
+            setField(member, "email", this.email, DEFAULT_EMAIL + emailCount++);
+            setField(member, "password", this.password, DEFAULT_PASSWORD);
+            setField(member, "nickname", this.nickname, DEFAULT_NICK_NAME + nickNameCount++);
+            setField(member, "socialInfo", this.socialInfo, null);
+            setField(member, "profileImageInfo", this.profileImageInfo, null);
+            setField(member, "devices", this.devices, List.of(new Device("testToken", member)));
+            setField(member, "deleted", this.deleted, false);
+            return member;
+        }
+
         private void setField(final Member member, final String fieldName, final Object value, final Object orElse) {
             final Field field = ReflectionUtils.findField(Member.class, fieldName);
             ReflectionUtils.makeAccessible(field);

--- a/backend/src/test/java/edonymyeon/backend/member/integration/MemberConsumptionIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/member/integration/MemberConsumptionIntegrationTest.java
@@ -5,13 +5,13 @@ import static edonymyeon.backend.member.integration.steps.MemberConsumptionSteps
 import static edonymyeon.backend.member.integration.steps.MemberConsumptionSteps.확정_취소_요청을_보낸다;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import edonymyeon.backend.support.IntegrationFixture;
 import edonymyeon.backend.global.controlleradvice.dto.ExceptionResponse;
 import edonymyeon.backend.global.exception.ExceptionInformation;
 import edonymyeon.backend.member.application.dto.request.PurchaseConfirmRequest;
 import edonymyeon.backend.member.application.dto.request.SavingConfirmRequest;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.post.domain.Post;
+import edonymyeon.backend.support.IntegrationFixture;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.assertj.core.api.SoftAssertions;

--- a/backend/src/test/java/edonymyeon/backend/notification/application/NotificationEventListenerTest.java
+++ b/backend/src/test/java/edonymyeon/backend/notification/application/NotificationEventListenerTest.java
@@ -1,19 +1,14 @@
 package edonymyeon.backend.notification.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
 
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.notification.repository.NotificationRepository;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.support.IntegrationFixture;
-import edonymyeon.backend.support.IntegrationTest;
-import edonymyeon.backend.support.MemberTestSupport;
-import edonymyeon.backend.support.PostTestSupport;
 import edonymyeon.backend.thumbs.application.ThumbsService;
 import edonymyeon.backend.thumbs.domain.Thumbs;
 import edonymyeon.backend.thumbs.repository.ThumbsRepository;
@@ -24,7 +19,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 
 @SuppressWarnings("NonAsciiCharacters")

--- a/backend/src/test/java/edonymyeon/backend/notification/integration/NotificationIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/notification/integration/NotificationIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.notification.application.dto.NotificationsResponse;
 import edonymyeon.backend.notification.domain.Notification;
 import edonymyeon.backend.notification.domain.ScreenType;
@@ -27,7 +28,7 @@ public class NotificationIntegrationTest extends IntegrationFixture implements I
     private final ThumbsService thumbsService;
 
     @Test
-    void 사용자가_받은_알림_목록을_조회한다() {
+    void 사용자가_받은_알림_목록을_조회한다(@Autowired MemberRepository memberRepository, @Autowired NotificationRepository notificationRepository) {
         final var 글쓴이 = 사용자를_하나_만든다();
         final var 열람인 = 사용자를_하나_만든다();
         final var 열람인2 = 사용자를_하나_만든다();

--- a/backend/src/test/java/edonymyeon/backend/post/application/MyPostServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/MyPostServiceTest.java
@@ -9,12 +9,11 @@ import static org.mockito.Mockito.when;
 import edonymyeon.backend.consumption.domain.Consumption;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.post.application.dto.response.MyPostResponse;
 import edonymyeon.backend.post.application.dto.response.PostConsumptionResponse;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;
-import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -27,7 +26,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
-import org.springframework.util.ReflectionUtils;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -56,7 +54,7 @@ class MyPostServiceTest {
         final Member 작성자 = testMemberBuilder.builder()
                 .id(1L)
                 .email("test@gmail.com")
-                .password("password")
+                .password("password123!")
                 .nickname("nickname")
                 .buildWithoutSaving();
 

--- a/backend/src/test/java/edonymyeon/backend/post/application/MyPostServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/MyPostServiceTest.java
@@ -1,21 +1,13 @@
 package edonymyeon.backend.post.application;
 
-import static edonymyeon.backend.consumption.domain.ConsumptionType.PURCHASE;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.when;
-
 import edonymyeon.backend.consumption.domain.Consumption;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.post.application.dto.response.MyPostResponse;
 import edonymyeon.backend.post.application.dto.response.PostConsumptionResponse;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;
-import java.util.List;
-import java.util.Map;
+import edonymyeon.backend.support.TestMemberBuilder;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -26,6 +18,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+import java.util.Map;
+
+import static edonymyeon.backend.consumption.domain.ConsumptionType.PURCHASE;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -53,9 +54,6 @@ class MyPostServiceTest {
 
         final Member 작성자 = testMemberBuilder.builder()
                 .id(1L)
-                .email("test@gmail.com")
-                .password("password123!")
-                .nickname("nickname")
                 .buildWithoutSaving();
 
         final List<Post> 게시글_목록 = 임의_게시글_목록(작성자);

--- a/backend/src/test/java/edonymyeon/backend/post/application/MyPostServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/MyPostServiceTest.java
@@ -13,6 +13,7 @@ import edonymyeon.backend.post.application.dto.response.MyPostResponse;
 import edonymyeon.backend.post.application.dto.response.PostConsumptionResponse;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -25,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import org.springframework.util.ReflectionUtils;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -47,7 +49,10 @@ class MyPostServiceTest {
         final GeneralFindingCondition findingCondition = GeneralFindingCondition.builder().build();
         final Pageable pageable = findingCondition.toPage();
 
-        final Member 작성자 = new Member(1L);
+        final Member 작성자 = new Member("test@gmail.com", "password", "nickName", null);
+        final Field memberIdField = ReflectionUtils.findField(Member.class, "id");
+        ReflectionUtils.makeAccessible(memberIdField);
+        ReflectionUtils.setField(memberIdField, 작성자, 1L);
 
         final List<Post> 게시글_목록 = 임의_게시글_목록(작성자);
         Slice<Post> 임의_반환_게시글_목록 = new SliceImpl<>(게시글_목록, pageable, true);

--- a/backend/src/test/java/edonymyeon/backend/post/application/MyPostServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/MyPostServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import edonymyeon.backend.consumption.domain.Consumption;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.post.application.dto.response.MyPostResponse;
 import edonymyeon.backend.post.application.dto.response.PostConsumptionResponse;
 import edonymyeon.backend.post.domain.Post;
@@ -35,6 +36,9 @@ class MyPostServiceTest {
 
     private static final int 소비확정_연 = 2020;
     private static final int 소비확정_달 = 1;
+
+    private final TestMemberBuilder testMemberBuilder = new TestMemberBuilder(null);
+
     @Mock
     private PostRepository postRepository;
 
@@ -49,10 +53,12 @@ class MyPostServiceTest {
         final GeneralFindingCondition findingCondition = GeneralFindingCondition.builder().build();
         final Pageable pageable = findingCondition.toPage();
 
-        final Member 작성자 = new Member("test@gmail.com", "password", "nickName", null);
-        final Field memberIdField = ReflectionUtils.findField(Member.class, "id");
-        ReflectionUtils.makeAccessible(memberIdField);
-        ReflectionUtils.setField(memberIdField, 작성자, 1L);
+        final Member 작성자 = testMemberBuilder.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .password("password")
+                .nickname("nickname")
+                .buildWithoutSaving();
 
         final List<Post> 게시글_목록 = 임의_게시글_목록(작성자);
         Slice<Post> 임의_반환_게시글_목록 = new SliceImpl<>(게시글_목록, pageable, true);

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostFindingSpecificPostTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostFindingSpecificPostTest.java
@@ -3,6 +3,7 @@ package edonymyeon.backend.post.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.TestConfig;
 import edonymyeon.backend.image.profileimage.domain.ProfileImageInfo;
@@ -14,7 +15,6 @@ import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;
-import edonymyeon.backend.support.MemberTestSupport;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,7 +32,7 @@ public class PostFindingSpecificPostTest {
 
     private final ProfileImageInfoRepository profileImageInfoRepository;
 
-    private final MemberTestSupport memberTestSupport;
+    private final TestMemberBuilder testMemberBuilder;
 
     private final PostReadService postReadService;
 
@@ -105,7 +105,7 @@ public class PostFindingSpecificPostTest {
     }
 
     private Member saveMember() {
-        final Member member = memberTestSupport.builder()
+        final Member member = testMemberBuilder.builder()
                 .profileImageInfo(saveProfileImageInfo())
                 .build();
         memberId = new ActiveMemberId(member.getId());
@@ -113,7 +113,7 @@ public class PostFindingSpecificPostTest {
     }
 
     private Member saveMember2() {
-        final Member member = memberTestSupport.builder()
+        final Member member = testMemberBuilder.builder()
                 .profileImageInfo(saveProfileImageInfo2())
                 .build();
         member2Id = new ActiveMemberId(memberRepository.save(member).getId());

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostFindingSpecificPostTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostFindingSpecificPostTest.java
@@ -3,7 +3,7 @@ package edonymyeon.backend.post.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.TestConfig;
 import edonymyeon.backend.image.profileimage.domain.ProfileImageInfo;

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostServiceSearchPostsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostServiceSearchPostsTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.support.PostTestSupport;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostServiceSearchPostsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostServiceSearchPostsTest.java
@@ -3,9 +3,9 @@ package edonymyeon.backend.post.application;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
-import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.support.MemberTestSupport;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.support.PostTestSupport;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,7 +20,7 @@ public class PostServiceSearchPostsTest {
 
     private final PostReadService postReadService;
 
-    private final MemberTestSupport memberTestSupport;
+    private final TestMemberBuilder memberTestSupport;
 
     private final PostTestSupport postTestSupport;
 

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
@@ -14,6 +14,7 @@ import edonymyeon.backend.image.postimage.repository.PostImageInfoRepository;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.application.dto.MemberId;
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.ImageFileCleaner;
 import edonymyeon.backend.post.application.dto.PostModificationRequest;
@@ -24,7 +25,6 @@ import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;
 import edonymyeon.backend.support.ConsumptionTestSupport;
 import edonymyeon.backend.support.IntegrationTest;
-import edonymyeon.backend.support.MemberTestSupport;
 import edonymyeon.backend.support.MockMultipartFileTestSupport;
 import jakarta.persistence.EntityManager;
 import java.io.File;
@@ -59,7 +59,7 @@ class PostServiceTest implements ImageFileCleaner {
 
     private final MemberRepository memberRepository;
 
-    private final MemberTestSupport memberTestSupport;
+    private final TestMemberBuilder memberTestSupport;
 
     private final MockMultipartFileTestSupport mockMultipartFileTestSupport;
 

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
@@ -1,9 +1,5 @@
 package edonymyeon.backend.post.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import edonymyeon.backend.TestConfig;
 import edonymyeon.backend.consumption.repository.ConsumptionRepository;
 import edonymyeon.backend.global.exception.EdonymyeonException;
@@ -14,7 +10,6 @@ import edonymyeon.backend.image.postimage.repository.PostImageInfoRepository;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.application.dto.MemberId;
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.ImageFileCleaner;
 import edonymyeon.backend.post.application.dto.PostModificationRequest;
@@ -26,13 +21,8 @@ import edonymyeon.backend.post.repository.PostRepository;
 import edonymyeon.backend.support.ConsumptionTestSupport;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.support.MockMultipartFileTestSupport;
+import edonymyeon.backend.support.TestMemberBuilder;
 import jakarta.persistence.EntityManager;
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,6 +32,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @SuppressWarnings("NonAsciiCharacters")
 @RequiredArgsConstructor
@@ -111,12 +112,7 @@ class PostServiceTest implements ImageFileCleaner {
 
     @Test
     void 작성자의_프로필_사진이_없더라도_상세조회가_가능하다() throws IOException {
-        final Member member = testMemberBuilder.builder()
-                .email("anonymous@gmail.com")
-                .password("password123!")
-                .nickname("nickname")
-                .buildWithoutSaving();
-        memberRepository.save(member);
+        final Member member = testMemberBuilder.builder().build();
 
         final ActiveMemberId memberId = new ActiveMemberId(member.getId());
         final PostResponse postResponse = postService.createPost(memberId, getPostRequest());

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
@@ -51,6 +51,8 @@ class PostServiceTest implements ImageFileCleaner {
 
     private static final Pattern 이미지_UUID_와_확장자_형식 = Pattern.compile("test-inserting\\d+\\.(png|jpg)");
 
+    private final TestMemberBuilder testMemberBuilder;
+
     private final PostImageInfoRepository postImageInfoRepository;
 
     private final PostService postService;
@@ -109,7 +111,11 @@ class PostServiceTest implements ImageFileCleaner {
 
     @Test
     void 작성자의_프로필_사진이_없더라도_상세조회가_가능하다() throws IOException {
-        final Member member = new Member("anonymous@gmail.com", "password123!", "엘렐레", null, List.of());
+        final Member member = testMemberBuilder.builder()
+                .email("anonymous@gmail.com")
+                .password("password123!")
+                .nickname("nickname")
+                .buildWithoutSaving();
         memberRepository.save(member);
 
         final ActiveMemberId memberId = new ActiveMemberId(member.getId());

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
@@ -14,7 +14,7 @@ import edonymyeon.backend.image.postimage.repository.PostImageInfoRepository;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.application.dto.MemberId;
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.ImageFileCleaner;
 import edonymyeon.backend.post.application.dto.PostModificationRequest;

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostViewTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostViewTest.java
@@ -2,6 +2,7 @@ package edonymyeon.backend.post.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.TestConfig;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
@@ -10,7 +11,6 @@ import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.post.ImageFileCleaner;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;
-import edonymyeon.backend.support.MemberTestSupport;
 import edonymyeon.backend.support.PostTestSupport;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,7 +27,7 @@ public class PostViewTest implements ImageFileCleaner {
 
     private final PostTestSupport postTestSupport;
 
-    private final MemberTestSupport memberTestSupport;
+    private final TestMemberBuilder memberTestSupport;
 
     private final PostRepository postRepository;
 

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostViewTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostViewTest.java
@@ -2,7 +2,7 @@ package edonymyeon.backend.post.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.TestConfig;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;

--- a/backend/src/test/java/edonymyeon/backend/post/docs/MyPostControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/docs/MyPostControllerDocsTest.java
@@ -1,5 +1,34 @@
 package edonymyeon.backend.post.docs;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edonymyeon.backend.image.domain.Domain;
+import edonymyeon.backend.image.postimage.domain.PostImageInfos;
+import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.repository.MemberRepository;
+import edonymyeon.backend.post.application.GeneralFindingCondition;
+import edonymyeon.backend.post.application.MyPostService;
+import edonymyeon.backend.post.application.PostSlice;
+import edonymyeon.backend.post.application.dto.response.MyPostResponse;
+import edonymyeon.backend.post.application.dto.response.PostConsumptionResponse;
+import edonymyeon.backend.post.domain.Post;
+import edonymyeon.backend.support.DocsTest;
+import edonymyeon.backend.support.TestMemberBuilder;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.headers.HeaderDescriptor;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.request.ParameterDescriptor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.util.List;
+import java.util.Optional;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
@@ -13,34 +42,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import edonymyeon.backend.image.domain.Domain;
-import edonymyeon.backend.image.postimage.domain.PostImageInfos;
-import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.support.TestMemberBuilder;
-import edonymyeon.backend.member.repository.MemberRepository;
-import edonymyeon.backend.post.application.GeneralFindingCondition;
-import edonymyeon.backend.post.application.MyPostService;
-import edonymyeon.backend.post.application.PostSlice;
-import edonymyeon.backend.post.application.dto.response.MyPostResponse;
-import edonymyeon.backend.post.application.dto.response.PostConsumptionResponse;
-import edonymyeon.backend.post.domain.Post;
-import edonymyeon.backend.support.DocsTest;
-import java.util.List;
-import java.util.Optional;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
-import org.springframework.http.HttpHeaders;
-import org.springframework.restdocs.headers.HeaderDescriptor;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.restdocs.payload.FieldDescriptor;
-import org.springframework.restdocs.request.ParameterDescriptor;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class MyPostControllerDocsTest extends DocsTest {
@@ -68,9 +69,6 @@ public class MyPostControllerDocsTest extends DocsTest {
         final GeneralFindingCondition findingCondition = GeneralFindingCondition.builder().build();
 
         final Member 회원 = testMemberBuilder.builder()
-                .email("example@example.com")
-                .password("password11234!")
-                .nickname("testNickname")
                 .buildWithoutSaving();
         회원_레포지토리를_모킹한다(회원);
 

--- a/backend/src/test/java/edonymyeon/backend/post/docs/MyPostControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/docs/MyPostControllerDocsTest.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edonymyeon.backend.image.domain.Domain;
 import edonymyeon.backend.image.postimage.domain.PostImageInfos;
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.application.GeneralFindingCondition;
 import edonymyeon.backend.post.application.MyPostService;
@@ -46,8 +47,12 @@ public class MyPostControllerDocsTest extends DocsTest {
 
     @Autowired
     private final Domain domain;
+
+    TestMemberBuilder testMemberBuilder = new TestMemberBuilder(null);
+
     @MockBean
     private MyPostService myPostService;
+
     @MockBean
     private MemberRepository memberRepository;
 
@@ -62,7 +67,11 @@ public class MyPostControllerDocsTest extends DocsTest {
     void 내_게시글_조회_문서화() throws Exception {
         final GeneralFindingCondition findingCondition = GeneralFindingCondition.builder().build();
 
-        Member 회원 = new Member("example@example.com", "password11234!", "testNickname", null, List.of());
+        final Member 회원 = testMemberBuilder.builder()
+                .email("example@example.com")
+                .password("password11234!")
+                .nickname("testNickname")
+                .buildWithoutSaving();
         회원_레포지토리를_모킹한다(회원);
 
         final Post 게시글1 = new Post(1L, "제목1", "내용1", 1000L, 회원, PostImageInfos.create(), 0);

--- a/backend/src/test/java/edonymyeon/backend/post/docs/MyPostControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/docs/MyPostControllerDocsTest.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edonymyeon.backend.image.domain.Domain;
 import edonymyeon.backend.image.postimage.domain.PostImageInfos;
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.application.GeneralFindingCondition;
 import edonymyeon.backend.post.application.MyPostService;

--- a/backend/src/test/java/edonymyeon/backend/post/docs/PostControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/docs/PostControllerDocsTest.java
@@ -1,7 +1,7 @@
 package edonymyeon.backend.post.docs;
 
 import edonymyeon.backend.CacheConfig;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.image.postimage.domain.PostImageInfo;
 import edonymyeon.backend.image.postimage.domain.PostImageInfos;
@@ -124,9 +124,6 @@ public class PostControllerDocsTest implements ImageFileCleaner {
     void 게시글을_수정한다() throws Exception {
         final Member 글쓴이 = testMemberBuilder.builder()
                 .id(1L)
-                .email("email")
-                .password("password")
-                .nickname("nickname")
                 .buildWithoutSaving();
 
         final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 글쓴이);
@@ -192,9 +189,6 @@ public class PostControllerDocsTest implements ImageFileCleaner {
     void 게시글을_삭제한다() throws Exception {
         final Member 글쓴이 = testMemberBuilder.builder()
                 .id(1L)
-                .email("email")
-                .password("password")
-                .nickname("nickname")
                 .buildWithoutSaving();
         final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 글쓴이);
 
@@ -227,9 +221,6 @@ public class PostControllerDocsTest implements ImageFileCleaner {
     void 게시글을_전체_조회한다() throws Exception {
         final Member 글쓴이 = testMemberBuilder.builder()
                 .id(1L)
-                .email("email")
-                .password("password")
-                .nickname("nickname")
                 .buildWithoutSaving();
         final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 글쓴이, PostImageInfos.create(), 0);
 
@@ -260,9 +251,6 @@ public class PostControllerDocsTest implements ImageFileCleaner {
 
         final Member 글쓴이 = testMemberBuilder.builder()
                 .id(1L)
-                .email("email")
-                .password("password")
-                .nickname("nickname")
                 .buildWithoutSaving();
         final Post 게시글 = new Post(1L, "햄버거 먹어도 되나요", "불고기 버거 세일중이던데", 1000L, 글쓴이, PostImageInfos.create(), 0);
 
@@ -315,9 +303,6 @@ public class PostControllerDocsTest implements ImageFileCleaner {
 
         final Member 글쓴이 = testMemberBuilder.builder()
                 .id(1L)
-                .email("email")
-                .password("password")
-                .nickname("nickname")
                 .buildWithoutSaving();
         final Post 게시글 = new Post(1L, "햄버거 먹어도 되나요", "불고기 버거 세일중이던데", 1000L, 글쓴이, PostImageInfos.create(), 0);
 
@@ -362,9 +347,6 @@ public class PostControllerDocsTest implements ImageFileCleaner {
     void 게시글을_상세_조회한다() throws Exception {
         final Member 글쓴이 = testMemberBuilder.builder()
                 .id(1L)
-                .email("email")
-                .password("password")
-                .nickname("nickname")
                 .buildWithoutSaving();
         final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 글쓴이, PostImageInfos.create(), 0);
 

--- a/backend/src/test/java/edonymyeon/backend/post/docs/PostControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/docs/PostControllerDocsTest.java
@@ -1,6 +1,7 @@
 package edonymyeon.backend.post.docs;
 
 import edonymyeon.backend.CacheConfig;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.image.postimage.domain.PostImageInfo;
 import edonymyeon.backend.image.postimage.domain.PostImageInfos;
@@ -67,6 +68,8 @@ public class PostControllerDocsTest implements ImageFileCleaner {
 
     private final MockMvc mockMvc;
 
+    private final TestMemberBuilder testMemberBuilder;
+
     @MockBean
     private MemberRepository memberRepository;
 
@@ -119,7 +122,13 @@ public class PostControllerDocsTest implements ImageFileCleaner {
 
     @Test
     void 게시글을_수정한다() throws Exception {
-        final Member 글쓴이 = new Member(1L, "email", "password", "nickname", null, null, List.of(), false);
+        final Member 글쓴이 = testMemberBuilder.builder()
+                .id(1L)
+                .email("email")
+                .password("password")
+                .nickname("nickname")
+                .buildWithoutSaving();
+
         final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 글쓴이);
         final PostImageInfo 유지하는_이미지_정보 = new PostImageInfo("stay.jpg", 게시글);
         final PostImageInfo 삭제될_이미지_정보 = new PostImageInfo("delete.jpg", 게시글);
@@ -181,7 +190,12 @@ public class PostControllerDocsTest implements ImageFileCleaner {
 
     @Test
     void 게시글을_삭제한다() throws Exception {
-        final Member 글쓴이 = new Member(1L, "email", "password", "nickname", null, null, List.of(), false);
+        final Member 글쓴이 = testMemberBuilder.builder()
+                .id(1L)
+                .email("email")
+                .password("password")
+                .nickname("nickname")
+                .buildWithoutSaving();
         final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 글쓴이);
 
         회원_레포지토리를_모킹한다(글쓴이);
@@ -211,7 +225,12 @@ public class PostControllerDocsTest implements ImageFileCleaner {
 
     @Test
     void 게시글을_전체_조회한다() throws Exception {
-        final Member 글쓴이 = new Member(1L, "email", "password", "nickname", null, null, List.of(), false);
+        final Member 글쓴이 = testMemberBuilder.builder()
+                .id(1L)
+                .email("email")
+                .password("password")
+                .nickname("nickname")
+                .buildWithoutSaving();
         final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 글쓴이, PostImageInfos.create(), 0);
 
         회원_레포지토리를_모킹한다(글쓴이);
@@ -239,7 +258,12 @@ public class PostControllerDocsTest implements ImageFileCleaner {
     void 게시글을_검색한다() throws Exception {
         final GeneralFindingCondition findingCondition = GeneralFindingCondition.builder().build();
 
-        final Member 글쓴이 = new Member(1L, "email", "password", "nickname", null, null, List.of(), false);
+        final Member 글쓴이 = testMemberBuilder.builder()
+                .id(1L)
+                .email("email")
+                .password("password")
+                .nickname("nickname")
+                .buildWithoutSaving();
         final Post 게시글 = new Post(1L, "햄버거 먹어도 되나요", "불고기 버거 세일중이던데", 1000L, 글쓴이, PostImageInfos.create(), 0);
 
         회원_레포지토리를_모킹한다(글쓴이);
@@ -289,7 +313,12 @@ public class PostControllerDocsTest implements ImageFileCleaner {
     void 핫_게시글을_조회한다() throws Exception {
         final HotFindingCondition findingCondition = HotFindingCondition.builder().build();
 
-        final Member 글쓴이 = new Member(1L, "email", "password", "nickname", null, null, List.of(), false);
+        final Member 글쓴이 = testMemberBuilder.builder()
+                .id(1L)
+                .email("email")
+                .password("password")
+                .nickname("nickname")
+                .buildWithoutSaving();
         final Post 게시글 = new Post(1L, "햄버거 먹어도 되나요", "불고기 버거 세일중이던데", 1000L, 글쓴이, PostImageInfos.create(), 0);
 
         회원_레포지토리를_모킹한다(글쓴이);
@@ -331,7 +360,12 @@ public class PostControllerDocsTest implements ImageFileCleaner {
 
     @Test
     void 게시글을_상세_조회한다() throws Exception {
-        final Member 글쓴이 = new Member(1L, "email", "password", "nickname", null, null, List.of(), false);
+        final Member 글쓴이 = testMemberBuilder.builder()
+                .id(1L)
+                .email("email")
+                .password("password")
+                .nickname("nickname")
+                .buildWithoutSaving();
         final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 글쓴이, PostImageInfos.create(), 0);
 
         회원_레포지토리를_모킹한다(글쓴이);

--- a/backend/src/test/java/edonymyeon/backend/post/docs/PostCreationDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/docs/PostCreationDocsTest.java
@@ -14,10 +14,10 @@ import static org.springframework.restdocs.request.RequestDocumentation.requestP
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.post.ImageFileCleaner;
-import edonymyeon.backend.support.MemberTestSupport;
 import jakarta.servlet.http.Part;
 import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
@@ -42,7 +42,7 @@ public class PostCreationDocsTest implements ImageFileCleaner {
 
     private final MockMvc mockMvc;
 
-    private final MemberTestSupport memberTestSupport;
+    private final TestMemberBuilder memberTestSupport;
 
     @Test
     void 게시글을_생성한다() throws Exception {

--- a/backend/src/test/java/edonymyeon/backend/post/docs/PostCreationDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/docs/PostCreationDocsTest.java
@@ -14,7 +14,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.requestP
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.post.ImageFileCleaner;

--- a/backend/src/test/java/edonymyeon/backend/post/repository/PostRepositoryTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/repository/PostRepositoryTest.java
@@ -1,16 +1,14 @@
 package edonymyeon.backend.post.repository;
 
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import edonymyeon.backend.member.application.dto.AnonymousMemberId;
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.post.application.HotFindingCondition;
 import edonymyeon.backend.post.application.PostReadService;
 import edonymyeon.backend.post.domain.HotPostPolicy;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.support.PostTestSupport;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.support.ThumbsUpPostTestSupport;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
@@ -18,6 +16,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @SuppressWarnings("NonAsciiCharacters")
 @RequiredArgsConstructor
@@ -40,11 +40,7 @@ class PostRepositoryTest {
 
     @BeforeEach
     public void setUp() {
-        member = testMemberBuilder.builder()
-                .email("email")
-                .password("password123!")
-                .nickname("nickname")
-                .build();
+        member = testMemberBuilder.builder().build();
     }
 
     @Test

--- a/backend/src/test/java/edonymyeon/backend/post/repository/PostRepositoryTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/repository/PostRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import edonymyeon.backend.member.application.dto.AnonymousMemberId;
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.application.HotFindingCondition;
 import edonymyeon.backend.post.application.PostReadService;
@@ -17,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -25,9 +27,9 @@ import org.springframework.data.domain.Slice;
 @IntegrationTest
 class PostRepositoryTest {
 
-    private final PostRepository postRepository;
+    private final TestMemberBuilder testMemberBuilder;
 
-    private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
 
     private final PostReadService postReadService;
 
@@ -41,14 +43,11 @@ class PostRepositoryTest {
 
     @BeforeEach
     public void setUp() {
-        member = new Member(
-                "email",
-                "password123!",
-                "nickname",
-                null,
-                List.of()
-        );
-        memberRepository.save(member);
+        member = testMemberBuilder.builder()
+                .email("email")
+                .password("password123!")
+                .nickname("nickname")
+                .build();
     }
 
     @Test

--- a/backend/src/test/java/edonymyeon/backend/post/repository/PostRepositoryTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/repository/PostRepositoryTest.java
@@ -4,8 +4,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import edonymyeon.backend.member.application.dto.AnonymousMemberId;
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
-import edonymyeon.backend.member.repository.MemberRepository;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.post.application.HotFindingCondition;
 import edonymyeon.backend.post.application.PostReadService;
 import edonymyeon.backend.post.domain.HotPostPolicy;
@@ -13,12 +12,10 @@ import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.support.PostTestSupport;
 import edonymyeon.backend.support.ThumbsUpPostTestSupport;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 

--- a/backend/src/test/java/edonymyeon/backend/post/ui/PostControllerTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/ui/PostControllerTest.java
@@ -5,12 +5,12 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.global.controlleradvice.dto.ExceptionResponse;
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.post.ImageFileCleaner;
 import edonymyeon.backend.post.application.dto.PostResponse;
-import edonymyeon.backend.support.MemberTestSupport;
+import edonymyeon.backend.support.IntegrationTest;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
@@ -54,14 +54,14 @@ class PostControllerTest implements ImageFileCleaner {
     }
 
     @Autowired
-    protected MemberTestSupport memberTestSupport;
+    protected TestMemberBuilder testMemberBuilder;
 
     @Autowired
     MockMvc mockMvc;
 
     @Test
     void 사진_첨부_성공_테스트() throws Exception {
-        final Member member = memberTestSupport.builder()
+        final Member member = testMemberBuilder.builder()
                 .build();
 
         mockMvc.perform(MockMvcRequestBuilders.multipart("/posts")
@@ -93,7 +93,7 @@ class PostControllerTest implements ImageFileCleaner {
 
     @Test
     void 본인이_작성한_게시글_삭제_가능_테스트() throws Exception {
-        final Member member = memberTestSupport.builder()
+        final Member member = testMemberBuilder.builder()
                 .build();
 
         final MvcResult 게시글_생성_요청_결과 = mockMvc.perform(MockMvcRequestBuilders.multipart("/posts")
@@ -128,7 +128,7 @@ class PostControllerTest implements ImageFileCleaner {
 
     @Test
     void 본인이_작성하지_않은_게시글_삭제_불가능_테스트() throws Exception {
-        final Member member = memberTestSupport.builder()
+        final Member member = testMemberBuilder.builder()
                 .build();
 
         final MvcResult 게시글_생성_요청_결과 = mockMvc.perform(MockMvcRequestBuilders.multipart("/posts")
@@ -145,7 +145,7 @@ class PostControllerTest implements ImageFileCleaner {
                 .andExpect(MockMvcResultMatchers.status().isCreated()).andReturn();
 
         PostResponse 게시글_생성_응답 = extractResponseFromResult(게시글_생성_요청_결과, PostResponse.class);
-        final Member otherMember = memberTestSupport.builder()
+        final Member otherMember = testMemberBuilder.builder()
                 .build();
 
         final MvcResult 게시글_삭제_요청_결과 = mockMvc.perform(MockMvcRequestBuilders.delete("/posts/" + 게시글_생성_응답.id())

--- a/backend/src/test/java/edonymyeon/backend/post/ui/PostControllerTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/ui/PostControllerTest.java
@@ -1,20 +1,13 @@
 package edonymyeon.backend.post.ui;
 
-import static edonymyeon.backend.global.exception.ExceptionInformation.POST_MEMBER_NOT_SAME;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edonymyeon.backend.global.controlleradvice.dto.ExceptionResponse;
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.post.ImageFileCleaner;
 import edonymyeon.backend.post.application.dto.PostResponse;
 import edonymyeon.backend.support.IntegrationTest;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
+import edonymyeon.backend.support.TestMemberBuilder;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -26,6 +19,14 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static edonymyeon.backend.global.exception.ExceptionInformation.POST_MEMBER_NOT_SAME;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @SuppressWarnings("NonAsciiCharacters")
 @AutoConfigureMockMvc
@@ -61,8 +62,7 @@ class PostControllerTest implements ImageFileCleaner {
 
     @Test
     void 사진_첨부_성공_테스트() throws Exception {
-        final Member member = testMemberBuilder.builder()
-                .build();
+        final Member member = testMemberBuilder.builder().build();
 
         mockMvc.perform(MockMvcRequestBuilders.multipart("/posts")
                         .file(이미지1)
@@ -93,8 +93,7 @@ class PostControllerTest implements ImageFileCleaner {
 
     @Test
     void 본인이_작성한_게시글_삭제_가능_테스트() throws Exception {
-        final Member member = testMemberBuilder.builder()
-                .build();
+        final Member member = testMemberBuilder.builder().build();
 
         final MvcResult 게시글_생성_요청_결과 = mockMvc.perform(MockMvcRequestBuilders.multipart("/posts")
                         .file(이미지1)
@@ -128,8 +127,7 @@ class PostControllerTest implements ImageFileCleaner {
 
     @Test
     void 본인이_작성하지_않은_게시글_삭제_불가능_테스트() throws Exception {
-        final Member member = testMemberBuilder.builder()
-                .build();
+        final Member member = testMemberBuilder.builder().build();
 
         final MvcResult 게시글_생성_요청_결과 = mockMvc.perform(MockMvcRequestBuilders.multipart("/posts")
                         .file(이미지1)
@@ -145,8 +143,7 @@ class PostControllerTest implements ImageFileCleaner {
                 .andExpect(MockMvcResultMatchers.status().isCreated()).andReturn();
 
         PostResponse 게시글_생성_응답 = extractResponseFromResult(게시글_생성_요청_결과, PostResponse.class);
-        final Member otherMember = testMemberBuilder.builder()
-                .build();
+        final Member otherMember = testMemberBuilder.builder().build();
 
         final MvcResult 게시글_삭제_요청_결과 = mockMvc.perform(MockMvcRequestBuilders.delete("/posts/" + 게시글_생성_응답.id())
                         .header(HttpHeaders.AUTHORIZATION, "Basic "

--- a/backend/src/test/java/edonymyeon/backend/post/ui/PostControllerTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/ui/PostControllerTest.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edonymyeon.backend.global.controlleradvice.dto.ExceptionResponse;
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.post.ImageFileCleaner;
 import edonymyeon.backend.post.application.dto.PostResponse;
 import edonymyeon.backend.support.IntegrationTest;

--- a/backend/src/test/java/edonymyeon/backend/report/ReportServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/report/ReportServiceTest.java
@@ -2,7 +2,7 @@ package edonymyeon.backend.report;
 
 import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.report.application.ReportRepository;
 import edonymyeon.backend.report.application.ReportRequest;

--- a/backend/src/test/java/edonymyeon/backend/report/ReportServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/report/ReportServiceTest.java
@@ -1,14 +1,14 @@
 package edonymyeon.backend.report;
 
-import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.report.application.ReportRepository;
 import edonymyeon.backend.report.application.ReportRequest;
 import edonymyeon.backend.report.application.ReportService;
 import edonymyeon.backend.report.domain.Report;
-import edonymyeon.backend.support.MemberTestSupport;
+import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.support.PostTestSupport;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
@@ -25,7 +25,7 @@ class ReportServiceTest {
 
     private final PostTestSupport postTestSupport;
 
-    private final MemberTestSupport memberTestSupport;
+    private final TestMemberBuilder memberTestSupport;
 
     @Test
     void 특정_게시글을_신고할_수_있다() {

--- a/backend/src/test/java/edonymyeon/backend/report/docs/ReportDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/report/docs/ReportDocsTest.java
@@ -10,7 +10,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.image.postimage.domain.PostImageInfos;
 import edonymyeon.backend.member.domain.Member;

--- a/backend/src/test/java/edonymyeon/backend/report/docs/ReportDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/report/docs/ReportDocsTest.java
@@ -10,6 +10,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.image.postimage.domain.PostImageInfos;
 import edonymyeon.backend.member.domain.Member;
@@ -45,6 +46,8 @@ public class ReportDocsTest implements ImageFileCleaner {
 
     private final ObjectMapper objectMapper;
 
+    private final TestMemberBuilder testMemberBuilder;
+
     @MockBean
     private MemberRepository memberRepository;
 
@@ -73,7 +76,12 @@ public class ReportDocsTest implements ImageFileCleaner {
 
     @Test
     void 게시글을_상세_조회한다() throws Exception {
-        final Member 글쓴이 = new Member(1L, "email", "password", "nickname", null, null, List.of(), false);
+        final Member 글쓴이 = testMemberBuilder.builder()
+                .id(1L)
+                .email("email@email.com")
+                .password("password123!")
+                .nickname("nickname")
+                .buildWithoutSaving();
         final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 글쓴이, PostImageInfos.create(), 0);
 
         회원_레포지토리를_모킹한다(글쓴이);

--- a/backend/src/test/java/edonymyeon/backend/setting/domain/SettingTest.java
+++ b/backend/src/test/java/edonymyeon/backend/setting/domain/SettingTest.java
@@ -3,15 +3,23 @@ package edonymyeon.backend.setting.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("NonAsciiCharacters")
 class SettingTest {
+    private final TestMemberBuilder testMemberBuilder = new TestMemberBuilder(null);
+
     @Test
     void 설정_항목을_체크하여_OnOff할_수_있다() {
-        final Member member = new Member(1L, "test@gmail.com", "password123", "nickName", null, null, List.of(), false);
+        final Member member = testMemberBuilder.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .password("password123")
+                .nickname("nickName")
+                .buildWithoutSaving();
         final Setting setting
                 = new Setting(member, SettingType.NOTIFICATION_PER_THUMB, Collections.emptyList(),
                 EnableStatus.ENABLED);
@@ -23,7 +31,12 @@ class SettingTest {
 
     @Test
     void 상위_항목을_disable하는_경우_하위_항목도_함께_disable된다() {
-        final Member member = new Member(1L, "test@gmail.com", "password123", "nickName", null, null, List.of(), false);
+        final Member member = testMemberBuilder.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .password("password123")
+                .nickname("nickName")
+                .buildWithoutSaving();
 
         final Setting 하위항목1 = new Setting(member, SettingType.NOTIFICATION_PER_THUMB, Collections.emptyList(),
                 EnableStatus.ENABLED);
@@ -42,7 +55,12 @@ class SettingTest {
 
     @Test
     void 상위_항목에_의해_disable된_항목이_상위_항목에_의해_다시_activated된_경우_이전의_설정을_다시_복구한다() {
-        final Member member = new Member("test@gmail.com", "password123!", "nickName", null, List.of());
+        final Member member = testMemberBuilder.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .password("password123")
+                .nickname("nickName")
+                .buildWithoutSaving();
 
         final Setting 하위항목1 = new Setting(member, SettingType.NOTIFICATION_PER_THUMB, Collections.emptyList(),
                 EnableStatus.ENABLED);

--- a/backend/src/test/java/edonymyeon/backend/setting/domain/SettingTest.java
+++ b/backend/src/test/java/edonymyeon/backend/setting/domain/SettingTest.java
@@ -3,7 +3,7 @@ package edonymyeon.backend.setting.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -16,9 +16,6 @@ class SettingTest {
     void 설정_항목을_체크하여_OnOff할_수_있다() {
         final Member member = testMemberBuilder.builder()
                 .id(1L)
-                .email("test@gmail.com")
-                .password("password123")
-                .nickname("nickName")
                 .buildWithoutSaving();
         final Setting setting
                 = new Setting(member, SettingType.NOTIFICATION_PER_THUMB, Collections.emptyList(),
@@ -33,9 +30,6 @@ class SettingTest {
     void 상위_항목을_disable하는_경우_하위_항목도_함께_disable된다() {
         final Member member = testMemberBuilder.builder()
                 .id(1L)
-                .email("test@gmail.com")
-                .password("password123")
-                .nickname("nickName")
                 .buildWithoutSaving();
 
         final Setting 하위항목1 = new Setting(member, SettingType.NOTIFICATION_PER_THUMB, Collections.emptyList(),
@@ -57,9 +51,6 @@ class SettingTest {
     void 상위_항목에_의해_disable된_항목이_상위_항목에_의해_다시_activated된_경우_이전의_설정을_다시_복구한다() {
         final Member member = testMemberBuilder.builder()
                 .id(1L)
-                .email("test@gmail.com")
-                .password("password123")
-                .nickname("nickName")
                 .buildWithoutSaving();
 
         final Setting 하위항목1 = new Setting(member, SettingType.NOTIFICATION_PER_THUMB, Collections.emptyList(),

--- a/backend/src/test/java/edonymyeon/backend/support/IntegrationFixture.java
+++ b/backend/src/test/java/edonymyeon/backend/support/IntegrationFixture.java
@@ -4,7 +4,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.notification.application.NotificationSender;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;

--- a/backend/src/test/java/edonymyeon/backend/support/IntegrationFixture.java
+++ b/backend/src/test/java/edonymyeon/backend/support/IntegrationFixture.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.notification.application.NotificationSender;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -25,7 +26,7 @@ public class IntegrationFixture {
     protected ProfileImageInfoTestSupport profileImageInfoTestSupport;
 
     @Autowired
-    protected MemberTestSupport memberTestSupport;
+    protected TestMemberBuilder memberTestSupport;
 
     @Autowired
     protected PostTestSupport postTestSupport;

--- a/backend/src/test/java/edonymyeon/backend/support/PostIntegrationTestSupport.java
+++ b/backend/src/test/java/edonymyeon/backend/support/PostIntegrationTestSupport.java
@@ -1,6 +1,7 @@
 package edonymyeon.backend.support;
 
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.post.repository.PostRepository;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -24,9 +25,7 @@ public class PostIntegrationTestSupport {
 
     private static File DEFAULT_IMAGE2 = new File("./src/test/resources/static/img/file/test_image_2.jpg");
 
-    private final PostRepository postRepository;
-
-    private final MemberTestSupport memberTestSupport;
+    private final TestMemberBuilder memberTestSupport;
 
     public PostIntegrationBuilder builder() {
         return new PostIntegrationBuilder();

--- a/backend/src/test/java/edonymyeon/backend/support/PostIntegrationTestSupport.java
+++ b/backend/src/test/java/edonymyeon/backend/support/PostIntegrationTestSupport.java
@@ -1,8 +1,6 @@
 package edonymyeon.backend.support;
 
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
-import edonymyeon.backend.post.repository.PostRepository;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;

--- a/backend/src/test/java/edonymyeon/backend/support/PostTestSupport.java
+++ b/backend/src/test/java/edonymyeon/backend/support/PostTestSupport.java
@@ -1,7 +1,6 @@
 package edonymyeon.backend.support;
 
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/test/java/edonymyeon/backend/support/PostTestSupport.java
+++ b/backend/src/test/java/edonymyeon/backend/support/PostTestSupport.java
@@ -1,6 +1,7 @@
 package edonymyeon.backend.support;
 
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,7 @@ public class PostTestSupport {
 
     private final PostRepository postRepository;
 
-    private final MemberTestSupport memberTestSupport;
+    private final TestMemberBuilder memberTestSupport;
 
     public PostBuilder builder() {
         return new PostBuilder();

--- a/backend/src/test/java/edonymyeon/backend/support/TestMemberBuilder.java
+++ b/backend/src/test/java/edonymyeon/backend/support/TestMemberBuilder.java
@@ -1,6 +1,9 @@
-package edonymyeon.backend.member.domain;
+package edonymyeon.backend.support;
 
 import edonymyeon.backend.image.profileimage.domain.ProfileImageInfo;
+import edonymyeon.backend.member.domain.Device;
+import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.domain.SocialInfo;
 import edonymyeon.backend.member.repository.MemberRepository;
 import java.lang.reflect.Field;
 import java.util.List;
@@ -88,26 +91,30 @@ public class TestMemberBuilder {
         }
 
         public Member build() {
-            final Member member = new Member();
+            final Member member = new Member(
+                    this.email != null ? this.email : DEFAULT_EMAIL + emailCount++,
+                    this.password != null ? this.password : DEFAULT_PASSWORD,
+                    this.nickname != null ? this.nickname : DEFAULT_NICK_NAME + nickNameCount++,
+                    this.profileImageInfo,
+                    List.of()
+            );
             setField(member, "id", this.id, null);
-            setField(member, "email", this.email, DEFAULT_EMAIL + emailCount++);
-            setField(member, "password", this.password, DEFAULT_PASSWORD);
-            setField(member, "nickname", this.nickname, DEFAULT_NICK_NAME + nickNameCount++);
             setField(member, "socialInfo", this.socialInfo, null);
-            setField(member, "profileImageInfo", this.profileImageInfo, null);
             setField(member, "devices", this.devices, List.of(new Device("testToken", member)));
             setField(member, "deleted", this.deleted, false);
             return memberRepository.save(member);
         }
 
         public Member buildWithoutSaving() {
-            final Member member = new Member();
+            final Member member = new Member(
+                    this.email != null ? this.email : DEFAULT_EMAIL + emailCount++,
+                    this.password != null ? this.password : DEFAULT_PASSWORD,
+                    this.nickname != null ? this.nickname : DEFAULT_NICK_NAME + nickNameCount++,
+                    this.profileImageInfo,
+                    List.of()
+            );
             setField(member, "id", this.id, null);
-            setField(member, "email", this.email, DEFAULT_EMAIL + emailCount++);
-            setField(member, "password", this.password, DEFAULT_PASSWORD);
-            setField(member, "nickname", this.nickname, DEFAULT_NICK_NAME + nickNameCount++);
             setField(member, "socialInfo", this.socialInfo, null);
-            setField(member, "profileImageInfo", this.profileImageInfo, null);
             setField(member, "devices", this.devices, List.of(new Device("testToken", member)));
             setField(member, "deleted", this.deleted, false);
             return member;

--- a/backend/src/test/java/edonymyeon/backend/support/ThumbsUpPostTestSupport.java
+++ b/backend/src/test/java/edonymyeon/backend/support/ThumbsUpPostTestSupport.java
@@ -1,7 +1,6 @@
 package edonymyeon.backend.support;
 
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.thumbs.domain.Thumbs;
 import edonymyeon.backend.thumbs.domain.ThumbsType;

--- a/backend/src/test/java/edonymyeon/backend/support/ThumbsUpPostTestSupport.java
+++ b/backend/src/test/java/edonymyeon/backend/support/ThumbsUpPostTestSupport.java
@@ -1,6 +1,7 @@
 package edonymyeon.backend.support;
 
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.thumbs.domain.Thumbs;
 import edonymyeon.backend.thumbs.domain.ThumbsType;
@@ -16,7 +17,7 @@ public class ThumbsUpPostTestSupport {
 
     private final PostTestSupport postTestSupport;
 
-    private final MemberTestSupport memberTestSupport;
+    private final TestMemberBuilder memberTestSupport;
 
     public ThumbsBuilder builder() {
         return new ThumbsBuilder();

--- a/backend/src/test/java/edonymyeon/backend/thumbs/application/DeleteThumbsServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/thumbs/application/DeleteThumbsServiceTest.java
@@ -5,21 +5,16 @@ import static edonymyeon.backend.global.exception.ExceptionInformation.THUMBS_DO
 import static edonymyeon.backend.global.exception.ExceptionInformation.THUMBS_UP_DELETE_FAIL_WHEN_THUMBS_DOWN;
 import static edonymyeon.backend.global.exception.ExceptionInformation.THUMBS_UP_IS_NOT_EXIST;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.application.dto.MemberId;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.repository.MemberRepository;
-import edonymyeon.backend.notification.application.NotificationSender;
 import edonymyeon.backend.post.application.PostService;
 import edonymyeon.backend.post.application.dto.PostRequest;
 import edonymyeon.backend.post.application.dto.PostResponse;
 import edonymyeon.backend.support.IntegrationFixture;
-import edonymyeon.backend.support.IntegrationTest;
-import edonymyeon.backend.support.MemberTestSupport;
 import edonymyeon.backend.thumbs.domain.Thumbs;
 import edonymyeon.backend.thumbs.repository.ThumbsRepository;
 import java.util.Optional;
@@ -28,7 +23,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SuppressWarnings("NonAsciiCharacters")
 @RequiredArgsConstructor

--- a/backend/src/test/java/edonymyeon/backend/thumbs/application/ThumbsDownServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/thumbs/application/ThumbsDownServiceTest.java
@@ -5,21 +5,16 @@ import static edonymyeon.backend.global.exception.ExceptionInformation.THUMBS_DO
 import static edonymyeon.backend.global.exception.ExceptionInformation.THUMBS_IS_SELF_UP_DOWN;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.application.dto.MemberId;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.repository.MemberRepository;
-import edonymyeon.backend.notification.application.NotificationSender;
 import edonymyeon.backend.post.application.PostService;
 import edonymyeon.backend.post.application.dto.PostRequest;
 import edonymyeon.backend.post.application.dto.PostResponse;
 import edonymyeon.backend.support.IntegrationFixture;
-import edonymyeon.backend.support.IntegrationTest;
-import edonymyeon.backend.support.MemberTestSupport;
 import edonymyeon.backend.thumbs.domain.Thumbs;
 import edonymyeon.backend.thumbs.domain.ThumbsType;
 import edonymyeon.backend.thumbs.repository.ThumbsRepository;
@@ -28,7 +23,6 @@ import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SuppressWarnings("NonAsciiCharacters")
 @RequiredArgsConstructor

--- a/backend/src/test/java/edonymyeon/backend/thumbs/application/ThumbsInPostServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/thumbs/application/ThumbsInPostServiceTest.java
@@ -1,28 +1,22 @@
 package edonymyeon.backend.thumbs.application;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
-import edonymyeon.backend.support.IntegrationFixture;
-import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.application.dto.AnonymousMemberId;
 import edonymyeon.backend.member.application.dto.MemberId;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.repository.MemberRepository;
-import edonymyeon.backend.notification.application.NotificationSender;
 import edonymyeon.backend.post.application.PostService;
 import edonymyeon.backend.post.application.PostThumbsService;
 import edonymyeon.backend.post.application.dto.AllThumbsInPostResponse;
 import edonymyeon.backend.post.application.dto.PostRequest;
 import edonymyeon.backend.post.application.dto.PostResponse;
 import edonymyeon.backend.post.application.dto.ThumbsStatusInPostResponse;
-import edonymyeon.backend.support.MemberTestSupport;
+import edonymyeon.backend.support.IntegrationFixture;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SuppressWarnings("NonAsciiCharacters")
 @RequiredArgsConstructor

--- a/backend/src/test/java/edonymyeon/backend/thumbs/application/ThumbsUpServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/thumbs/application/ThumbsUpServiceTest.java
@@ -5,21 +5,16 @@ import static edonymyeon.backend.global.exception.ExceptionInformation.THUMBS_IS
 import static edonymyeon.backend.global.exception.ExceptionInformation.THUMBS_UP_ALREADY_EXIST;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
-import edonymyeon.backend.support.IntegrationFixture;
-import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.application.dto.MemberId;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.repository.MemberRepository;
-import edonymyeon.backend.notification.application.NotificationSender;
 import edonymyeon.backend.post.application.PostService;
 import edonymyeon.backend.post.application.dto.PostRequest;
 import edonymyeon.backend.post.application.dto.PostResponse;
-import edonymyeon.backend.support.MemberTestSupport;
+import edonymyeon.backend.support.IntegrationFixture;
 import edonymyeon.backend.thumbs.domain.Thumbs;
 import edonymyeon.backend.thumbs.domain.ThumbsType;
 import edonymyeon.backend.thumbs.repository.ThumbsRepository;
@@ -28,7 +23,6 @@ import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SuppressWarnings("NonAsciiCharacters")
 @RequiredArgsConstructor

--- a/backend/src/test/java/edonymyeon/backend/thumbs/docs/ThumbsControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/thumbs/docs/ThumbsControllerDocsTest.java
@@ -11,6 +11,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;
@@ -18,8 +19,6 @@ import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.thumbs.domain.Thumbs;
 import edonymyeon.backend.thumbs.domain.ThumbsType;
 import edonymyeon.backend.thumbs.repository.ThumbsRepository;
-import java.lang.reflect.Field;
-import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,7 +29,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.util.ReflectionUtils;
 
 @SuppressWarnings("NonAsciiCharacters")
 @RequiredArgsConstructor
@@ -40,6 +38,8 @@ import org.springframework.util.ReflectionUtils;
 public class ThumbsControllerDocsTest {
 
     private final MockMvc mockMvc;
+
+    private final TestMemberBuilder testMemberBuilder;
 
     @MockBean
     private MemberRepository memberRepository;
@@ -60,16 +60,23 @@ public class ThumbsControllerDocsTest {
     }
 
     void 회원_두명_가입하고_글쓰기_모킹() {
-        글쓴이 = new Member("email", "password123!", "nickname", null, List.of());
-        final Field 글쓴이idField = ReflectionUtils.findField(Member.class, "id");
-        ReflectionUtils.makeAccessible(글쓴이idField);
-        ReflectionUtils.setField(글쓴이idField, 글쓴이, 1L);
+        글쓴이 = testMemberBuilder.builder()
+                .id(1L)
+                .email("email")
+                .password("password123!")
+                .nickname("nickname")
+                .buildWithoutSaving();
 
         when(memberRepository.findByEmail(글쓴이.getEmail())).thenReturn(Optional.of(글쓴이));
         when(memberRepository.findById(글쓴이.getId())).thenReturn(Optional.of(글쓴이));
 
-        반응_하는_사람 = new Member("email2", "password123!", "nickname2", null, List.of());
-        ReflectionUtils.setField(글쓴이idField, 반응_하는_사람, 2L);
+        반응_하는_사람 = testMemberBuilder.builder()
+                .id(2L)
+                .email("email2")
+                .password("password123!")
+                .nickname("nickname2")
+                .buildWithoutSaving();
+
         when(memberRepository.findByEmail(반응_하는_사람.getEmail())).thenReturn(
                 Optional.of(반응_하는_사람));
         when(memberRepository.findById(반응_하는_사람.getId())).thenReturn(Optional.of(반응_하는_사람));

--- a/backend/src/test/java/edonymyeon/backend/thumbs/docs/ThumbsControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/thumbs/docs/ThumbsControllerDocsTest.java
@@ -1,25 +1,14 @@
 package edonymyeon.backend.thumbs.docs;
 
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;
 import edonymyeon.backend.support.IntegrationTest;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.thumbs.domain.Thumbs;
 import edonymyeon.backend.thumbs.domain.ThumbsType;
 import edonymyeon.backend.thumbs.repository.ThumbsRepository;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,6 +18,18 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SuppressWarnings("NonAsciiCharacters")
 @RequiredArgsConstructor
@@ -62,9 +63,6 @@ public class ThumbsControllerDocsTest {
     void 회원_두명_가입하고_글쓰기_모킹() {
         글쓴이 = testMemberBuilder.builder()
                 .id(1L)
-                .email("email")
-                .password("password123!")
-                .nickname("nickname")
                 .buildWithoutSaving();
 
         when(memberRepository.findByEmail(글쓴이.getEmail())).thenReturn(Optional.of(글쓴이));
@@ -72,9 +70,6 @@ public class ThumbsControllerDocsTest {
 
         반응_하는_사람 = testMemberBuilder.builder()
                 .id(2L)
-                .email("email2")
-                .password("password123!")
-                .nickname("nickname2")
                 .buildWithoutSaving();
 
         when(memberRepository.findByEmail(반응_하는_사람.getEmail())).thenReturn(

--- a/backend/src/test/java/edonymyeon/backend/thumbs/docs/ThumbsControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/thumbs/docs/ThumbsControllerDocsTest.java
@@ -11,7 +11,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;

--- a/backend/src/test/java/edonymyeon/backend/thumbs/domain/AllThumbsInPostTest.java
+++ b/backend/src/test/java/edonymyeon/backend/thumbs/domain/AllThumbsInPostTest.java
@@ -1,15 +1,16 @@
 package edonymyeon.backend.thumbs.domain;
 
+import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.post.domain.Post;
+import edonymyeon.backend.support.TestMemberBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
 import static edonymyeon.backend.thumbs.domain.ThumbsType.DOWN;
 import static edonymyeon.backend.thumbs.domain.ThumbsType.UP;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
-import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.support.TestMemberBuilder;
-import edonymyeon.backend.post.domain.Post;
-import java.util.Collections;
-import java.util.List;
-import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("NonAsciiCharacters")
 class AllThumbsInPostTest {
@@ -30,9 +31,6 @@ class AllThumbsInPostTest {
     @Test
     void 추천과_비추천이_수를_제대로_카운트_한다() {
         Member member = testMemberBuilder.builder()
-                .email("email")
-                .password("password123!")
-                .nickname("nick")
                 .buildWithoutSaving();
 
         Post post = new Post("title", "content", 100L, member);

--- a/backend/src/test/java/edonymyeon/backend/thumbs/domain/AllThumbsInPostTest.java
+++ b/backend/src/test/java/edonymyeon/backend/thumbs/domain/AllThumbsInPostTest.java
@@ -5,6 +5,7 @@ import static edonymyeon.backend.thumbs.domain.ThumbsType.UP;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.domain.TestMemberBuilder;
 import edonymyeon.backend.post.domain.Post;
 import java.util.Collections;
 import java.util.List;
@@ -12,6 +13,8 @@ import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("NonAsciiCharacters")
 class AllThumbsInPostTest {
+
+    private final TestMemberBuilder testMemberBuilder = new TestMemberBuilder(null);
 
     @Test
     void 추천과_비추천이_모두_0이다() {
@@ -26,7 +29,12 @@ class AllThumbsInPostTest {
 
     @Test
     void 추천과_비추천이_수를_제대로_카운트_한다() {
-        Member member = new Member("email", "password123!", "nick", null, List.of());
+        Member member = testMemberBuilder.builder()
+                .email("email")
+                .password("password123!")
+                .nickname("nick")
+                .buildWithoutSaving();
+
         Post post = new Post("title", "content", 100L, member);
 
         List<Thumbs> thumbs = List.of(

--- a/backend/src/test/java/edonymyeon/backend/thumbs/domain/AllThumbsInPostTest.java
+++ b/backend/src/test/java/edonymyeon/backend/thumbs/domain/AllThumbsInPostTest.java
@@ -5,7 +5,7 @@ import static edonymyeon.backend.thumbs.domain.ThumbsType.UP;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.member.domain.TestMemberBuilder;
+import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.post.domain.Post;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #342 

## 📝 작업 요약

Member 엔티티에서 테스트에만 사용되는 생성자를 제거했습니다.

## 🔎 작업 상세 설명

테스트에서 필요한 Member 객체 생성을 할 때에는
실제 클래스의 생성자를 불필요하게 늘리는 대신
테스트 레이어에서 기본 생성자 + Reflection를 활용해 생성할 수 있도록 하였습니다.

