### PR TITLE
fix: 게시글 검색시, 검색어 조건이 아예 없을때 전체 목록이 조회되는 이슈 수정

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/post/repository/PostSpecification.java
+++ b/backend/src/main/java/edonymyeon/backend/post/repository/PostSpecification.java
@@ -4,22 +4,33 @@ import edonymyeon.backend.post.domain.Post;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import org.springframework.data.jpa.domain.Specification;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import org.springframework.data.jpa.domain.Specification;
 
 public class PostSpecification {
 
     public static Specification<Post> searchBy(String searchWord) {
         return ((root, query, criteriaBuilder) -> {
             List<Predicate> predicates = new ArrayList<>();
-            if (Objects.nonNull(searchWord) && !searchWord.isBlank()) {
-                appendSearchCondition(searchWord, root, criteriaBuilder, predicates);
+            if (Objects.isNull(searchWord) || searchWord.isBlank()) {
+                appendNoCondition(criteriaBuilder, predicates);
+                return combineAllConditions(criteriaBuilder, predicates);
             }
-            return criteriaBuilder.and(predicates.toArray(Predicate[]::new));
+            appendSearchCondition(searchWord, root, criteriaBuilder, predicates);
+            return combineAllConditions(criteriaBuilder, predicates);
         });
+    }
+
+    private static void appendNoCondition(CriteriaBuilder criteriaBuilder, List<Predicate> predicates) {
+        predicates.add(criteriaBuilder.disjunction());
+    }
+
+    private static Predicate combineAllConditions(CriteriaBuilder criteriaBuilder, List<Predicate> predicates) {
+        return criteriaBuilder.and(predicates.toArray(Predicate[]::new));
     }
 
     private static void appendSearchCondition(String searchWord, Root<Post> root, CriteriaBuilder criteriaBuilder,

--- a/backend/src/test/java/edonymyeon/backend/post/integration/PostSearchIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/integration/PostSearchIntegrationTest.java
@@ -1,17 +1,17 @@
 package edonymyeon.backend.post.integration;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
-import edonymyeon.backend.support.IntegrationFixture;
 import edonymyeon.backend.global.exception.ExceptionInformation;
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.support.IntegrationFixture;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class PostSearchIntegrationTest extends IntegrationFixture {
@@ -92,6 +92,21 @@ public class PostSearchIntegrationTest extends IntegrationFixture {
                 .given()
                 .when()
                 .queryParam("query", "케로로")
+                .get("/search")
+                .then()
+                .extract();
+
+        final var jsonPath = 검색된_게시글_조회_결과.body().jsonPath();
+
+        assertThat(jsonPath.getList("content").size()).isEqualTo(0);
+    }
+
+    @Test
+    void 빈_값을_검색하면_빈_리스트가_조회된다() {
+        final var 검색된_게시글_조회_결과 = RestAssured
+                .given()
+                .when()
+                .queryParam("query", "")
                 .get("/search")
                 .then()
                 .extract();

--- a/backend/src/test/java/edonymyeon/backend/post/repository/PostSpecificationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/repository/PostSpecificationTest.java
@@ -1,17 +1,18 @@
 package edonymyeon.backend.post.repository;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-
-import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.post.domain.Post;
+import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.support.PostTestSupport;
-import java.util.Arrays;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.data.jpa.domain.Specification;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @SuppressWarnings("NonAsciiCharacters")
 @RequiredArgsConstructor
@@ -55,6 +56,19 @@ public class PostSpecificationTest {
         List<Post> all = postRepository.findAll(searchedBy);
 
         assertThat(all.size()).isEqualTo(1);
+    }
+
+    @Test
+    void 빈_검색어를_검색하면_빈_값이_나온다() {
+        postTestSupport.builder()
+                .title("ecec")
+                .content("I use EnGlish and KoRean")
+                .build();
+
+        Specification<Post> searchedBy = PostSpecification.searchBy("");
+        List<Post> all = postRepository.findAll(searchedBy);
+
+        assertThat(all.size()).isEqualTo(0);
     }
 }
 


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #357 

## 📝 작업 요약

검색어를 아무것도 입력하지 않고 빈 값을 검색하면 전체게시글이 아닌 빈 리스트가 조회되도록 수정하였다.
