### PR TITLE
Fix/#359 캐싱된 핫게시글이 없을떄 npe 오류 해결

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/cache/application/HotPostsRedisRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/cache/application/HotPostsRedisRepository.java
@@ -1,6 +1,6 @@
 package edonymyeon.backend.cache.application;
 
-import edonymyeon.backend.cache.application.domain.CachedHotPost;
+import edonymyeon.backend.cache.domain.CachedHotPost;
 import org.springframework.data.repository.CrudRepository;
 
 public interface HotPostsRedisRepository extends CrudRepository<CachedHotPost, String> {

--- a/backend/src/main/java/edonymyeon/backend/cache/application/PostCachingService.java
+++ b/backend/src/main/java/edonymyeon/backend/cache/application/PostCachingService.java
@@ -1,6 +1,6 @@
 package edonymyeon.backend.cache.application;
 
-import edonymyeon.backend.cache.application.domain.CachedHotPost;
+import edonymyeon.backend.cache.domain.CachedHotPost;
 import edonymyeon.backend.cache.application.dto.CachedPostResponse;
 import edonymyeon.backend.cache.util.HotPostCachePolicy;
 import edonymyeon.backend.global.exception.EdonymyeonException;

--- a/backend/src/main/java/edonymyeon/backend/cache/domain/CachedHotPost.java
+++ b/backend/src/main/java/edonymyeon/backend/cache/domain/CachedHotPost.java
@@ -1,4 +1,4 @@
-package edonymyeon.backend.cache.application.domain;
+package edonymyeon.backend.cache.domain;
 
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;

--- a/backend/src/main/java/edonymyeon/backend/cache/domain/CachedHotPost.java
+++ b/backend/src/main/java/edonymyeon/backend/cache/domain/CachedHotPost.java
@@ -7,7 +7,10 @@ import org.springframework.data.redis.core.RedisHash;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 @AllArgsConstructor
 @Getter
@@ -30,9 +33,24 @@ public class CachedHotPost {
     }
 
     public void refreshData(final List<Long> hotPostIds, final boolean isLast) {
-        this.postIds.clear();
+        initializePostIds();
         this.postIds.addAll(hotPostIds);
         this.isLast = isLast;
         refreshTime = LocalDateTime.now();
+    }
+
+    private void initializePostIds() {
+        if (Objects.nonNull(this.postIds)) {
+            this.postIds.clear();
+            return;
+        }
+        this.postIds = new ArrayList<>();
+    }
+
+    public List<Long> getPostIds() {
+        if(Objects.isNull(this.postIds)){
+            return Collections.emptyList();
+        }
+        return this.postIds;
     }
 }

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostServiceHotPostsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostServiceHotPostsTest.java
@@ -5,6 +5,7 @@ import edonymyeon.backend.cache.application.HotPostsRedisRepository;
 import edonymyeon.backend.cache.application.PostCachingService;
 import edonymyeon.backend.cache.util.HotPostCachePolicy;
 import edonymyeon.backend.post.application.dto.GeneralPostInfoResponse;
+import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.support.PostTestSupport;


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #359 

## 📝 작업 요약

핫 게시글이 없다면 레디스에 빈 리스트가 저장 되는데, 빈 리스트 대신 null 로 저장됩니다
이로 인해 핫 게시글 조회에서 NPE 이 발생하는 것을 확인했습니다.
때문에 CachedHotPost 도메인에서 캐시를 refresh 하거나, get할때 null처리를 추가해주었습니다.
