### PR TITLE
Feat/#372 댓글만 조회하는 API 구현

### DIFF
--- a/backend/src/docs/asciidoc/common/comment-api.adoc
+++ b/backend/src/docs/asciidoc/common/comment-api.adoc
@@ -7,4 +7,7 @@ operation::comment-create[snippets='request-headers,path-parameters,request-part
 === 댓글 삭제
 operation::comment-delete[snippets='request-headers,path-parameters,http-request,http-response']
 
+=== 하나의 게시물에 대한 댓글만 조회
+operation::comment-findAllByPost[snippets='path-parameters,http-request,http-response,response-fields']
+
 

--- a/backend/src/main/java/edonymyeon/backend/comment/application/dto/request/CommentRequest.java
+++ b/backend/src/main/java/edonymyeon/backend/comment/application/dto/request/CommentRequest.java
@@ -1,4 +1,4 @@
-package edonymyeon.backend.comment.application.dto;
+package edonymyeon.backend.comment.application.dto.request;
 
 import org.springframework.web.multipart.MultipartFile;
 

--- a/backend/src/main/java/edonymyeon/backend/comment/application/dto/response/CommentDto.java
+++ b/backend/src/main/java/edonymyeon/backend/comment/application/dto/response/CommentDto.java
@@ -1,0 +1,14 @@
+package edonymyeon.backend.comment.application.dto.response;
+
+import java.time.LocalDateTime;
+
+public record CommentDto(
+        Long id,
+        String image,
+        String comment,
+        boolean isWriter,
+        LocalDateTime createdAt,
+        WriterDto writer
+) {
+
+}

--- a/backend/src/main/java/edonymyeon/backend/comment/application/dto/response/CommentDto.java
+++ b/backend/src/main/java/edonymyeon/backend/comment/application/dto/response/CommentDto.java
@@ -1,5 +1,6 @@
 package edonymyeon.backend.comment.application.dto.response;
 
+import edonymyeon.backend.comment.domain.Comment;
 import java.time.LocalDateTime;
 
 public record CommentDto(
@@ -11,4 +12,14 @@ public record CommentDto(
         WriterDto writer
 ) {
 
+    public static CommentDto of(final boolean isWriter, final Comment comment, final String image) {
+        return new CommentDto(
+                comment.getId(),
+                image,
+                comment.getContent(),
+                isWriter,
+                comment.getCreatedAt(),
+                new WriterDto(comment.getMember().getNickname())
+        );
+    }
 }

--- a/backend/src/main/java/edonymyeon/backend/comment/application/dto/response/CommentsResponse.java
+++ b/backend/src/main/java/edonymyeon/backend/comment/application/dto/response/CommentsResponse.java
@@ -1,0 +1,7 @@
+package edonymyeon.backend.comment.application.dto.response;
+
+import java.util.List;
+
+public record CommentsResponse(List<CommentDto> comments) {
+
+}

--- a/backend/src/main/java/edonymyeon/backend/comment/application/dto/response/WriterDto.java
+++ b/backend/src/main/java/edonymyeon/backend/comment/application/dto/response/WriterDto.java
@@ -1,0 +1,5 @@
+package edonymyeon.backend.comment.application.dto.response;
+
+public record WriterDto(String nickname) {
+
+}

--- a/backend/src/main/java/edonymyeon/backend/comment/domain/Comment.java
+++ b/backend/src/main/java/edonymyeon/backend/comment/domain/Comment.java
@@ -72,9 +72,12 @@ public class Comment extends TemporalRecord {
     }
 
     public void checkWriter(final Long memberId) {
-        // todo: 여우의 PR 반영해서 member 비교하는거 고치기
-        if (!member.getId().equals(memberId)) {
+        if (!member.hasId(memberId)) {
             throw new EdonymyeonException(COMMENT_MEMBER_NOT_SAME);
         }
+    }
+
+    public boolean isSameMember(final Long memberId) {
+        return this.member.hasId(memberId);
     }
 }

--- a/backend/src/main/java/edonymyeon/backend/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package edonymyeon.backend.comment.repository;
 
 import edonymyeon.backend.comment.domain.Comment;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @EntityGraph(attributePaths = {"member", "commentImageInfo"})
     Optional<Comment> findByIdAndPostId(final Long id, final Long postId);
+
+    @EntityGraph(attributePaths = {"post", "member", "commentImageInfo"})
+    List<Comment> findAllByPostId(final Long postId);
 }

--- a/backend/src/main/java/edonymyeon/backend/comment/ui/CommentController.java
+++ b/backend/src/main/java/edonymyeon/backend/comment/ui/CommentController.java
@@ -2,12 +2,14 @@ package edonymyeon.backend.comment.ui;
 
 import edonymyeon.backend.auth.annotation.AuthPrincipal;
 import edonymyeon.backend.comment.application.CommentService;
-import edonymyeon.backend.comment.application.dto.CommentRequest;
+import edonymyeon.backend.comment.application.dto.request.CommentRequest;
+import edonymyeon.backend.comment.application.dto.response.CommentsResponse;
 import edonymyeon.backend.member.application.dto.MemberId;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -37,5 +39,12 @@ public class CommentController {
         commentService.deleteComment(memberId, postId, commentId);
         return ResponseEntity.noContent()
                 .build();
+    }
+
+    @GetMapping
+    public ResponseEntity<CommentsResponse> findCommentsByPostId(@AuthPrincipal(required = false) MemberId memberId,
+                                                                 @PathVariable Long postId) {
+        final CommentsResponse response = commentService.findCommentsByPostId(memberId, postId);
+        return ResponseEntity.ok().body(response);
     }
 }

--- a/backend/src/test/java/edonymyeon/backend/comment/docs/CommentControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/comment/docs/CommentControllerDocsTest.java
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import edonymyeon.backend.comment.application.CommentService;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.support.IntegrationTest;
-import edonymyeon.backend.support.MemberTestSupport;
+import edonymyeon.backend.support.TestMemberBuilder;
 import jakarta.servlet.http.Part;
 import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
@@ -51,7 +51,7 @@ public class CommentControllerDocsTest {
     @MockBean
     private final CommentService commentService;
 
-    private final MemberTestSupport memberTestSupport;
+    private final TestMemberBuilder memberTestSupport;
 
     @Test
     void 댓글을_작성한다() throws Exception {

--- a/backend/src/test/java/edonymyeon/backend/comment/docs/CommentControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/comment/docs/CommentControllerDocsTest.java
@@ -8,10 +8,13 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.headerWit
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
@@ -20,11 +23,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import edonymyeon.backend.comment.application.CommentService;
+import edonymyeon.backend.comment.application.dto.response.CommentDto;
+import edonymyeon.backend.comment.application.dto.response.CommentsResponse;
+import edonymyeon.backend.comment.application.dto.response.WriterDto;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.support.TestMemberBuilder;
 import jakarta.servlet.http.Part;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.apache.http.entity.ContentType;
 import org.junit.jupiter.api.Test;
@@ -114,6 +122,62 @@ public class CommentControllerDocsTest {
 
         mockMvc.perform(댓글_삭제_요청)
                 .andExpect(status().isNoContent())
+                .andDo(문서화);
+    }
+
+    @Test
+    void 댓글을_조회한다() throws Exception {
+        final CommentsResponse commentsResponse = new CommentsResponse(
+                List.of(
+                        new CommentDto(
+                                4L,
+                                "http://edonymyeon.site/images/image1.png",
+                                "그건 너무 비싸용",
+                                false,
+                                LocalDateTime.now(),
+                                new WriterDto("훈수쟁이")
+                        ),
+                        new CommentDto(
+                                8L,
+                                "http://edonymyeon.site/images/image2.png",
+                                "그돈이면 치킨이 세마리",
+                                false,
+                                LocalDateTime.now(),
+                                new WriterDto("훈수충")
+                        ),
+                        new CommentDto(
+                                9L,
+                                "http://edonymyeon.site/images/image3.png",
+                                "배고프다",
+                                false,
+                                LocalDateTime.now(),
+                                new WriterDto("거지")
+                        )
+                )
+        );
+        when(commentService.findCommentsByPostId(any(), anyLong())).thenReturn(commentsResponse);
+
+        final MockHttpServletRequestBuilder 댓글_조회_요청 = get("/posts/{postId}/comments", 1L)
+                .contentType(MediaType.APPLICATION_JSON_VALUE);
+
+        final RestDocumentationResultHandler 문서화 = document("comment-findAllByPost",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("postId").description("게시글 id")
+                ),
+                responseFields(
+                        fieldWithPath("comments[].id").description("댓글 id"),
+                        fieldWithPath("comments[].image").description("댓글에 첨부된 사진의 url"),
+                        fieldWithPath("comments[].comment").description("댓글 본문"),
+                        fieldWithPath("comments[].isWriter").description("댓글 조회 요청을 보낸 사용자가 댓글 작성자 본인인지 여부"),
+                        fieldWithPath("comments[].createdAt").description("댓글 작성 시각"),
+                        fieldWithPath("comments[].writer.nickname").description("댓글 작성자의 닉네임")
+                )
+        );
+
+        mockMvc.perform(댓글_조회_요청)
+                .andExpect(status().isOk())
                 .andDo(문서화);
     }
 }

--- a/backend/src/test/java/edonymyeon/backend/comment/integration/CommentIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/comment/integration/CommentIntegrationTest.java
@@ -6,7 +6,6 @@ import static edonymyeon.backend.global.exception.ExceptionInformation.POST_ID_N
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
-import edonymyeon.backend.CacheConfig;
 import edonymyeon.backend.TestConfig;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.post.ImageFileCleaner;
@@ -182,14 +181,16 @@ public class CommentIntegrationTest extends IntegrationFixture implements ImageF
                     assertThat(댓글_조회_응답.jsonPath().getString("comments[0].comment")).isEqualTo("this is comment1");
                     assertThat(댓글_조회_응답.jsonPath().getString("comments[0].createdAt")).isNotBlank();
                     assertThat(댓글_조회_응답.jsonPath().getBoolean("comments[0].isWriter")).isFalse();
-                    assertThat(댓글_조회_응답.jsonPath().getString("comments[0].writer.nickname")).isEqualTo(댓글_작성자.getNickname());
+                    assertThat(댓글_조회_응답.jsonPath().getString("comments[0].writer.nickname")).isEqualTo(
+                            댓글_작성자.getNickname());
 
                     assertThat(댓글_조회_응답.jsonPath().getInt("comments[1].id")).isEqualTo(댓글2_id);
                     assertThat(이미지_형식.matcher(댓글_조회_응답.jsonPath().getString("comments[1].image")).matches()).isTrue();
                     assertThat(댓글_조회_응답.jsonPath().getString("comments[1].comment")).isEqualTo("this is comment2");
                     assertThat(댓글_조회_응답.jsonPath().getString("comments[1].createdAt")).isNotBlank();
                     assertThat(댓글_조회_응답.jsonPath().getBoolean("comments[1].isWriter")).isFalse();
-                    assertThat(댓글_조회_응답.jsonPath().getString("comments[1].writer.nickname")).isEqualTo(댓글_작성자.getNickname());
+                    assertThat(댓글_조회_응답.jsonPath().getString("comments[1].writer.nickname")).isEqualTo(
+                            댓글_작성자.getNickname());
                 }
         );
     }
@@ -219,14 +220,16 @@ public class CommentIntegrationTest extends IntegrationFixture implements ImageF
                     assertThat(댓글_조회_응답.jsonPath().getString("comments[0].comment")).isEqualTo("this is comment1");
                     assertThat(댓글_조회_응답.jsonPath().getString("comments[0].createdAt")).isNotBlank();
                     assertThat(댓글_조회_응답.jsonPath().getBoolean("comments[1].isWriter")).isTrue();
-                    assertThat(댓글_조회_응답.jsonPath().getString("comments[0].writer.nickname")).isEqualTo(댓글_작성자.getNickname());
+                    assertThat(댓글_조회_응답.jsonPath().getString("comments[0].writer.nickname")).isEqualTo(
+                            댓글_작성자.getNickname());
 
                     assertThat(댓글_조회_응답.jsonPath().getInt("comments[1].id")).isEqualTo(댓글2_id);
                     assertThat(이미지_형식.matcher(댓글_조회_응답.jsonPath().getString("comments[1].image")).matches()).isTrue();
                     assertThat(댓글_조회_응답.jsonPath().getString("comments[1].comment")).isEqualTo("this is comment2");
                     assertThat(댓글_조회_응답.jsonPath().getString("comments[1].createdAt")).isNotBlank();
                     assertThat(댓글_조회_응답.jsonPath().getBoolean("comments[1].isWriter")).isTrue();
-                    assertThat(댓글_조회_응답.jsonPath().getString("comments[1].writer.nickname")).isEqualTo(댓글_작성자.getNickname());
+                    assertThat(댓글_조회_응답.jsonPath().getString("comments[1].writer.nickname")).isEqualTo(
+                            댓글_작성자.getNickname());
                 }
         );
     }

--- a/backend/src/test/java/edonymyeon/backend/support/CommentTestSupport.java
+++ b/backend/src/test/java/edonymyeon/backend/support/CommentTestSupport.java
@@ -14,7 +14,7 @@ public class CommentTestSupport {
 
     private final PostTestSupport postTestSupport;
 
-    private final MemberTestSupport memberTestSupport;
+    private final TestMemberBuilder memberTestSupport;
 
     private final CommentRepository commentRepository;
 


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #372 

## 📝 작업 요약

댓글만 조회하는 API 구현

## 🔎 작업 상세 설명

안드로이드와 상의 후, 게시글에 댓글을 달았을 때에는 댓글만 조회하는 api가 필요하다고 판단되어
게시글 id가 주어지면 해당 게시글의 댓글들만 조회하는 api를 구현하였습니다.
사용자가 로그인이 되어있든, 안되어있든 조회가 가능합니다.

(1)상세 게시글 조회 api에 댓글응답을 넣을지, (2)상세 게시글 조회 api는 현재 상태 그대로 유지하고, 댓글만 조회 api를 추가적으로 이용해서 댓글을 조회할지는 추후에 계속 논의 예정입니다. (일단 후자로 진행해 보기로 하는데 안드로이드측에서 진행해보고 전자로 변경될 가능성도 존재)
