### PR TITLE
fix: 댓글 작성 요청에서 이미지 값이 null로 들어오는 경우 처리

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/comment/application/CommentService.java
+++ b/backend/src/main/java/edonymyeon/backend/comment/application/CommentService.java
@@ -58,7 +58,7 @@ public class CommentService {
     }
 
     private CommentImageInfo extractCommentImageInfo(final MultipartFile image) {
-        if (image.isEmpty()) {
+        if (image == null || image.isEmpty()) {
             return null;
         }
         final CommentImageInfo commentImageInfo = CommentImageInfo.from(imageFileUploader.uploadFile(image));


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #381 

## 📝 작업 요약

안드로이드에서 댓글 작성 시 이미지가 없을 경우, 이미지 값을 null로 보내는데, 이를 처리하였습니다.
