### PR TITLE
feat: 핫게시글 정책에 댓글 가중치를 추가한다.

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/post/application/PostReadService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostReadService.java
@@ -167,6 +167,7 @@ public class PostReadService {
                 HotPostPolicy.getFindPeriod(),
                 HotPostPolicy.getViewCountWeight(),
                 HotPostPolicy.getThumbsCountWeight(),
+                HotPostPolicy.getCommentCountWeight(),
                 hotFindingCondition.toPage()
         );
     }

--- a/backend/src/main/java/edonymyeon/backend/post/domain/HotPostPolicy.java
+++ b/backend/src/main/java/edonymyeon/backend/post/domain/HotPostPolicy.java
@@ -11,6 +11,8 @@ public class HotPostPolicy {
 
     private static final int THUMBS_COUNT_WEIGHT = 3;
 
+    private static final int COMMENT_COUNT_WEIGHT = 5;
+
     public static LocalDateTime getFindPeriod(){
         return LocalDateTime.now()
                 .minus(FINDING_PERIOD, ChronoUnit.DAYS);
@@ -22,5 +24,9 @@ public class HotPostPolicy {
 
     public static int getThumbsCountWeight(){
         return THUMBS_COUNT_WEIGHT;
+    }
+
+    public static int getCommentCountWeight() {
+        return COMMENT_COUNT_WEIGHT;
     }
 }

--- a/backend/src/main/java/edonymyeon/backend/post/repository/PostRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/post/repository/PostRepository.java
@@ -35,15 +35,19 @@ public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificat
             FROM Post p
             LEFT JOIN Thumbs t
             ON p.id = t.post.id
+            LEFT JOIN Comment c
+            ON p.id = c.post.id
             WHERE p.createdAt >= :findStartDate
             GROUP BY p.id
-            ORDER BY (COUNT(t.id) * :thumbsCountWeight + p.viewCount * :viewCountWeight) DESC, p.createdAt ASC
+            ORDER BY (COUNT(t.id) * :thumbsCountWeight + COUNT(c.id) * :commentCountWeight + p.viewCount * :viewCountWeight) DESC, 
+            p.createdAt ASC
             """)
     Slice<Post> findHotPosts(
             @Param("findStartDate") final LocalDateTime findStartDate,
             @Param("viewCountWeight") final int viewCountWeight,
             @Param("thumbsCountWeight") final int thumbsCountWeight,
-            Pageable pageable);
+            @Param("commentCountWeight") final int commentCountWeight,
+            final Pageable pageable);
 
     @EntityGraph(attributePaths = "member")
     @Query("SELECT p FROM Post p WHERE p.id IN (:postIds)")

--- a/backend/src/test/java/edonymyeon/backend/post/docs/PostControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/docs/PostControllerDocsTest.java
@@ -1,6 +1,7 @@
 package edonymyeon.backend.post.docs;
 
 import edonymyeon.backend.CacheConfig;
+import edonymyeon.backend.post.domain.HotPostPolicy;
 import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.image.postimage.domain.PostImageInfo;
@@ -100,7 +101,7 @@ public class PostControllerDocsTest implements ImageFileCleaner {
     }
 
     private void 핫_게시글_조회를_모킹한다(final Post 게시글) {
-        when(postRepository.findHotPosts(any(LocalDateTime.class), anyInt(), anyInt(), any()))
+        when(postRepository.findHotPosts(any(LocalDateTime.class), anyInt(), anyInt(), HotPostPolicy.getCommentCountWeight(), any()))
                 .thenReturn(new SliceImpl<>(List.of(게시글)));
         when(postRepository.findByIds(anyList()))
                 .thenReturn(List.of(게시글));

--- a/backend/src/test/java/edonymyeon/backend/post/repository/PostRepositoryTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/repository/PostRepositoryTest.java
@@ -6,10 +6,7 @@ import edonymyeon.backend.post.application.HotFindingCondition;
 import edonymyeon.backend.post.application.PostReadService;
 import edonymyeon.backend.post.domain.HotPostPolicy;
 import edonymyeon.backend.post.domain.Post;
-import edonymyeon.backend.support.IntegrationTest;
-import edonymyeon.backend.support.PostTestSupport;
-import edonymyeon.backend.support.TestMemberBuilder;
-import edonymyeon.backend.support.ThumbsUpPostTestSupport;
+import edonymyeon.backend.support.*;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,6 +22,8 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 class PostRepositoryTest {
 
     private final TestMemberBuilder testMemberBuilder;
+
+    private final CommentTestSupport commentTestSupport;
 
     private final PostRepository postRepository;
 
@@ -61,18 +60,18 @@ class PostRepositoryTest {
     }
 
     @Test
-    void 최근_게시글이_없다면_빈_리스트가_조회된다() {
+    void 최근_게시글이_없다면_핫게시글은_빈_리스트가_조회된다() {
         Slice<Post> hotPosts = postRepository.findHotPosts(
                 HotPostPolicy.getFindPeriod(),
                 HotPostPolicy.getViewCountWeight(),
                 HotPostPolicy.getThumbsCountWeight(),
-                page);
+                HotPostPolicy.getCommentCountWeight(), page);
 
         Assertions.assertThat(hotPosts.isEmpty()).isTrue();
     }
 
     @Test
-    void findHotPosts_메서드에서_thumbs_테이블에_정보가_없어도_제대로_조인되는지_확인한다() {
+    void findHotPosts_메서드에서_thumbs_테이블과_comment_테이블에_정보가_없어도_제대로_조인되는지_확인한다() {
         // given
         Post post1 = postTestSupport.builder().build();
         Post post2 = postTestSupport.builder().build();
@@ -85,7 +84,7 @@ class PostRepositoryTest {
                 HotPostPolicy.getFindPeriod(),
                 HotPostPolicy.getViewCountWeight(),
                 HotPostPolicy.getThumbsCountWeight(),
-                page);
+                HotPostPolicy.getCommentCountWeight(), page);
 
         for (Post hotPost : hotPosts) {
             System.out.println("hotPost = " + hotPost.getId() + hotPost.getTitle());
@@ -100,7 +99,52 @@ class PostRepositoryTest {
     }
 
     @Test
-    void 인기순_대로_게시글이_조회되는지_확인한다() {
+    void 핫게시글에서_인기순_대로_게시글이_조회되는지_확인한다_댓글_없는_버전() {
+        // given
+        Post score8Post = postTestSupport.builder().build();
+        Post score6Post = postTestSupport.builder().build();
+        Post score9Post = postTestSupport.builder().build();
+        Post score10Post = postTestSupport.builder().build();
+        Post score5Post = postTestSupport.builder().build();
+
+        // when
+        thumbsPostTestSupport.builder().post(score8Post).build();
+        commentTestSupport.builder().post(score8Post).build();
+
+        thumbsPostTestSupport.builder().post(score6Post).build();
+        thumbsPostTestSupport.builder().post(score6Post).build();
+
+        commentTestSupport.builder().post(score9Post).build();
+        thumbsPostTestSupport.builder().post(score9Post).build();
+        postReadService.findSpecificPost(score9Post.getId(), new AnonymousMemberId());
+
+        commentTestSupport.builder().post(score10Post).build();
+        thumbsPostTestSupport.builder().post(score10Post).build();
+        postReadService.findSpecificPost(score10Post.getId(), new AnonymousMemberId());
+        postReadService.findSpecificPost(score10Post.getId(), new AnonymousMemberId());
+
+        commentTestSupport.builder().post(score5Post).build();
+
+        // then
+        Slice<Post> hotPosts = postRepository.findHotPosts(
+                HotPostPolicy.getFindPeriod(),
+                HotPostPolicy.getViewCountWeight(),
+                HotPostPolicy.getThumbsCountWeight(),
+                HotPostPolicy.getCommentCountWeight(), page);
+
+        assertSoftly(softly -> {
+                    softly.assertThat(hotPosts.get().toList().size()).isEqualTo(5);
+                    softly.assertThat(hotPosts.get().toList().get(0).getId()).isEqualTo(score10Post.getId());
+                    softly.assertThat(hotPosts.get().toList().get(1).getId()).isEqualTo(score9Post.getId());
+                    softly.assertThat(hotPosts.get().toList().get(2).getId()).isEqualTo(score8Post.getId());
+                    softly.assertThat(hotPosts.get().toList().get(3).getId()).isEqualTo(score6Post.getId());
+                    softly.assertThat(hotPosts.get().toList().get(4).getId()).isEqualTo(score5Post.getId());
+                }
+        );
+    }
+
+    @Test
+    void 핫게시글에서_인기순_대로_게시글이_조회되는지_확인한다_댓글_있는_버전() {
         // given
         Post score8Post = postTestSupport.builder().build();
         Post score6Post = postTestSupport.builder().build();
@@ -126,6 +170,7 @@ class PostRepositoryTest {
         thumbsPostTestSupport.builder().post(score10Post).build();
         postReadService.findSpecificPost(score10Post.getId(), new AnonymousMemberId());
 
+
         thumbsPostTestSupport.builder().post(score5Post).build();
         postReadService.findSpecificPost(score5Post.getId(), new AnonymousMemberId());
         postReadService.findSpecificPost(score5Post.getId(), new AnonymousMemberId());
@@ -135,7 +180,7 @@ class PostRepositoryTest {
                 HotPostPolicy.getFindPeriod(),
                 HotPostPolicy.getViewCountWeight(),
                 HotPostPolicy.getThumbsCountWeight(),
-                page);
+                HotPostPolicy.getCommentCountWeight(), page);
 
         assertSoftly(softly -> {
                     softly.assertThat(hotPosts.get().toList().size()).isEqualTo(5);
@@ -149,7 +194,7 @@ class PostRepositoryTest {
     }
 
     @Test
-    void 동점일_경우_오래된_순서로_정렬된다() {
+    void 핫게시글에서_동점일_경우_오래된_순서로_정렬된다() {
         // given
         Post score0Post1 = postTestSupport.builder().build();
         Post score0Post2 = postTestSupport.builder().build();
@@ -166,7 +211,7 @@ class PostRepositoryTest {
                 HotPostPolicy.getFindPeriod(),
                 HotPostPolicy.getViewCountWeight(),
                 HotPostPolicy.getThumbsCountWeight(),
-                page);
+                HotPostPolicy.getCommentCountWeight(), page);
 
         assertSoftly(softly -> {
                     softly.assertThat(hotPosts.get().toList().size()).isEqualTo(5);


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #384 

## 📝 작업 요약

핫 게시글 정책에 댓글 개수 가중치를 더했습니다 (˶′◡‵˶) ( ´▽｀)

## 🔎 작업 상세 설명

큰 변동은 없으니 확인만 해도 될 것 갓습니다 
궁금해서 더미 데이터 100개정도 넣고 쿼리 실행계획을 돌려보았습니다 !
다시 보니 저도 잘 못보겠네요 ㅎㅎ 암턴 잘 아시는 분 훈수 부탁드립니다 .

<img width="1052" alt="image" src="https://github.com/woowacourse-teams/2023-edonymyeon/assets/103317169/5dc992a5-8d36-4c9a-ad22-ac103c55f662">


``` sql
EXPLAIN
SELECT p.id, COUNT(t.id) * 3 +COUNT(c.id) * 5 + p.view_count AS weighted_score
FROM Post p
LEFT JOIN Thumbs t
ON p.id = t.post_id
LEFT JOIN Comment c
ON p.id = c.post_id
WHERE p.created_at >= DATE_SUB(CURDATE(), INTERVAL 7 DAY)
GROUP BY p.id
ORDER BY weighted_score DESC
LIMIT 20 OFFSET 1;
```
쿼리 실행 계획

| id | select\_type | table | partitions | type | possible\_keys | key | key\_len | ref | rows | filtered | Extra |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 1 | SIMPLE | p | null | index | PRIMARY,FK83s99f4kx8oiqm3ro0sasmpww | PRIMARY | 8 | null | 100 | 33.33 | Using where; Using temporary; Using filesort |
| 1 | SIMPLE | t | null | ref | FKnrqs0uqm5lnra6j2p5eibpiek | FKnrqs0uqm5lnra6j2p5eibpiek | 9 | edon.p.id | 17 | 100 | Using index |
| 1 | SIMPLE | c | null | ref | FKs1slvnkuemjsq2kj4h3vhx7i1 | FKs1slvnkuemjsq2kj4h3vhx7i1 | 8 | edon.p.id | 20 | 100 | Using index |

쿼리 실행 (날짜 순 order는 빠져있습니다)

| id | weighted\_score |
| :--- | :--- |
| 91 | 8 |
| 76 | 8 |
| 61 | 8 |
| 46 | 8 |
| 31 | 8 |
| 16 | 8 |
| 51 | 5 |
| 96 | 5 |
| 86 | 5 |
| 11 | 5 |
| 81 | 5 |
| 71 | 5 |
| 66 | 5 |
| 56 | 5 |
| 41 | 5 |
| 36 | 5 |
| 6 | 5 |
| 26 | 5 |
| 21 | 5 |
| 100 | 3 |
