### PR TITLE
fix: 댓글 글자수 제한을 게시글 글자수 제한과 동일하도록 수정

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/comment/domain/Comment.java
+++ b/backend/src/main/java/edonymyeon/backend/comment/domain/Comment.java
@@ -38,7 +38,7 @@ public class Comment extends TemporalRecord {
     @JoinColumn(nullable = false)
     private Post post;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "longtext")
     private String content;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/resources/db/migration/mysql/V1.2.1__change_comment_longtext.sql
+++ b/backend/src/main/resources/db/migration/mysql/V1.2.1__change_comment_longtext.sql
@@ -1,0 +1,1 @@
+ALTER TABLE comment MODIFY COLUMN content longtext not null;

--- a/backend/src/test/java/edonymyeon/backend/comment/integration/CommentIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/comment/integration/CommentIntegrationTest.java
@@ -320,7 +320,6 @@ public class CommentIntegrationTest extends IntegrationFixture implements ImageF
         final Member 댓글_작성자 = memberTestSupport.builder().build();
         String 엄청긴내용 = "https://www.google.com/search?q=%EA%B5%AD%EB%B0%A5&sca_esv=563011930&sxsrf=AB5stBiDy2a0MwlQmu6VB-8YpfjsEyjxEQ:1693986737909&tbm=isch&source=iu&ictx=1&vet=1&fir=sIvtHEk9_U_o5M%252CpD1Tq-sHZpN7AM%252C%252Fg%252F12392002%253B4HF-UXGBj8FhYM%252CE9uWSBBha3D_gM%252C_%253BJYaErMf7-y-c_M%252CrSd-S_vLxb3sGM%252C_%253BpkfPdVq-V8ZlSM%252CMMk5hcmb_gk_3M%252C_%253BdzDN-T5gf8f6bM%252CP3XbliiGuxt2fM%252C_%253BJNdLHh8L8dOAEM%252CGCZOxBwC4UaqpM%252C_&usg=AI4_-kQ5oFr6wN3omZLxhEDp75ruIzRELQ&sa=X&sqi=2&ved=2ahUKEwjSrpGuwJWBAxWI-2EKHaIzD84Q_B16BAhHEAE#imgrc=sIvtHEk9_U_o5M";
 
-
         final File 이미지 = new File("./src/test/resources/static/img/file/test_image_1.jpg");
         final ExtractableResponse<Response> 댓글_생성_응답 = 댓글을_생성한다(게시글.getId(), 이미지, 엄청긴내용, 댓글_작성자);
 

--- a/backend/src/test/java/edonymyeon/backend/comment/integration/CommentIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/comment/integration/CommentIntegrationTest.java
@@ -313,4 +313,17 @@ public class CommentIntegrationTest extends IntegrationFixture implements ImageF
                 }
         );
     }
+
+    @Test
+    void 엄청_긴_댓글을_작성한다() {
+        final Post 게시글 = postTestSupport.builder().build();
+        final Member 댓글_작성자 = memberTestSupport.builder().build();
+        String 엄청긴내용 = "https://www.google.com/search?q=%EA%B5%AD%EB%B0%A5&sca_esv=563011930&sxsrf=AB5stBiDy2a0MwlQmu6VB-8YpfjsEyjxEQ:1693986737909&tbm=isch&source=iu&ictx=1&vet=1&fir=sIvtHEk9_U_o5M%252CpD1Tq-sHZpN7AM%252C%252Fg%252F12392002%253B4HF-UXGBj8FhYM%252CE9uWSBBha3D_gM%252C_%253BJYaErMf7-y-c_M%252CrSd-S_vLxb3sGM%252C_%253BpkfPdVq-V8ZlSM%252CMMk5hcmb_gk_3M%252C_%253BdzDN-T5gf8f6bM%252CP3XbliiGuxt2fM%252C_%253BJNdLHh8L8dOAEM%252CGCZOxBwC4UaqpM%252C_&usg=AI4_-kQ5oFr6wN3omZLxhEDp75ruIzRELQ&sa=X&sqi=2&ved=2ahUKEwjSrpGuwJWBAxWI-2EKHaIzD84Q_B16BAhHEAE#imgrc=sIvtHEk9_U_o5M";
+
+
+        final File 이미지 = new File("./src/test/resources/static/img/file/test_image_1.jpg");
+        final ExtractableResponse<Response> 댓글_생성_응답 = 댓글을_생성한다(게시글.getId(), 이미지, 엄청긴내용, 댓글_작성자);
+
+        assertThat(댓글_생성_응답.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
 }


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #386 

## 📝 작업 요약

구글의 기다란 url은 댓글을 달 수 없는 이슈가 있어서,
댓글이 db에 저장될때 longtext로 저장되도록 수정하였습니다.

*현재 PR중에 여우의 알림PR, 그리고 추후에 구현되어야 하는 케로의 댓글 신고기능에서 Flyway가 적용되어야 하는데, merge 순서에 따른 flyway 파일의 버전 관리에 유의해야합니다.