### PR TITLE
fix: 게시글 삭제시 댓글의 이미지가 deleted 컬럼이 true로 바뀌지 않던 이슈 수정

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/comment/repository/CommentRepository.java
@@ -17,7 +17,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @EntityGraph(attributePaths = {"post", "member", "commentImageInfo"})
     List<Comment> findAllByPostId(final Long postId);
 
-    @Modifying
+    @Modifying //todo: 옵션.. 이대로 괜찮은가?
     @Query("update Comment c set c.deleted = true where c.post.id = :postId")
     void deleteAllByPostId(@Param("postId") Long postId);
 }

--- a/backend/src/main/java/edonymyeon/backend/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/comment/repository/CommentRepository.java
@@ -17,7 +17,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @EntityGraph(attributePaths = {"post", "member", "commentImageInfo"})
     List<Comment> findAllByPostId(final Long postId);
 
-    @Modifying(flushAutomatically = true, clearAutomatically = false)
+    @Modifying
     @Query("update Comment c set c.deleted = true where c.post.id = :postId")
     void deleteAllByPostId(@Param("postId") Long postId);
 }

--- a/backend/src/main/java/edonymyeon/backend/image/commentimage/repository/CommentImageInfoRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/image/commentimage/repository/CommentImageInfoRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface CommentImageInfoRepository extends JpaRepository<CommentImageInfo, Long> {
 
-    @Modifying
+    @Modifying //todo: 옵션.. 이대로 괜찮은가?
     @Query("update CommentImageInfo c set c.deleted = true where c.id in :ids")
     void deleteAllById(@Param("ids") List<Long> ids);
 }

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
@@ -98,7 +98,7 @@ public class PostService {
         // todo: 소비내역 삭제할 때, 이벤트 대신 인터페이스로 변경
         applicationEventPublisher.publishEvent(new PostDeletionEvent(post.getId()));
         thumbsService.deleteAllThumbsInPost(postId);
-        commentService.deleteAllCommentsInPost(postId); //영속성 컨텍스트와 관련있는 bulk 연산이라 맨 뒤에 둠
+        commentService.deleteAllCommentsInPost(postId);
         post.delete();
     }
 

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
@@ -98,8 +98,8 @@ public class PostService {
         // todo: 소비내역 삭제할 때, 이벤트 대신 인터페이스로 변경
         applicationEventPublisher.publishEvent(new PostDeletionEvent(post.getId()));
         thumbsService.deleteAllThumbsInPost(postId);
-        post.delete();
         commentService.deleteAllCommentsInPost(postId); //영속성 컨텍스트와 관련있는 bulk 연산이라 맨 뒤에 둠
+        post.delete();
     }
 
     private Post findPostById(final Long postId) {


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #416 

post가 delete true된 상태에서 commentRepositoryByPostId를 하면 조회 결과가 무조건 없는 것을 알게되었습니다.
따라서 post를 delete true하는 동작을 PostService의 게시글 삭제 로직의 제일 뒤로 빼고, commentRepository의 @Modifying의 옵션을 수정했습니다. (삭제할때만 사용하는 것이라 괜찮을 것이라 판단)

추후 더 좋은 대안이 생각나면 리팩터링하도록 하겠습니다.
