### PR TITLE
Refactor/#418 회원 프로필 삭제

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
+++ b/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
@@ -2,6 +2,7 @@ package edonymyeon.backend.auth.application;
 
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_EMAIL_DUPLICATE;
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_EMAIL_NOT_FOUND;
+import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_ID_NOT_FOUND;
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_IS_DELETED;
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_NICKNAME_INVALID;
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_PASSWORD_NOT_MATCH;
@@ -16,6 +17,7 @@ import edonymyeon.backend.auth.application.event.LogoutEvent;
 import edonymyeon.backend.auth.domain.PasswordEncoder;
 import edonymyeon.backend.auth.domain.ValidateType;
 import edonymyeon.backend.global.exception.EdonymyeonException;
+import edonymyeon.backend.member.application.MemberService;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.application.dto.MemberId;
 import edonymyeon.backend.member.domain.Member;
@@ -41,6 +43,8 @@ public class AuthService {
     private final MemberRepository memberRepository;
 
     private final PasswordEncoder passwordEncoder;
+
+    private final MemberService memberService;
 
     public MemberId login(final LoginRequest loginRequest) {
         final Member member = authenticateMember(loginRequest.email(), loginRequest.password());
@@ -155,5 +159,13 @@ public class AuthService {
 
     public void logout(String deviceToken) {
         publisher.publishEvent(new LogoutEvent(deviceToken));
+    }
+
+    @Transactional
+    public void deleteMember(final MemberId memberId) {
+        final Member member = memberRepository.findById(memberId.id())
+                .orElseThrow(() -> new EdonymyeonException(MEMBER_ID_NOT_FOUND));
+        memberService.deleteProfileImage(member);
+        member.withdraw();
     }
 }

--- a/backend/src/main/java/edonymyeon/backend/auth/ui/AuthController.java
+++ b/backend/src/main/java/edonymyeon/backend/auth/ui/AuthController.java
@@ -1,5 +1,7 @@
 package edonymyeon.backend.auth.ui;
 
+import static edonymyeon.backend.auth.ui.SessionConst.USER;
+
 import edonymyeon.backend.auth.application.AuthService;
 import edonymyeon.backend.auth.application.KakaoAuthResponseProvider;
 import edonymyeon.backend.auth.application.dto.DuplicateCheckResponse;
@@ -8,16 +10,12 @@ import edonymyeon.backend.auth.application.dto.KakaoLoginRequest;
 import edonymyeon.backend.auth.application.dto.KakaoLoginResponse;
 import edonymyeon.backend.auth.application.dto.LoginRequest;
 import edonymyeon.backend.auth.application.dto.LogoutRequest;
-import edonymyeon.backend.auth.application.dto.MemberResponse;
-import edonymyeon.backend.auth.domain.TokenGenerator;
-import edonymyeon.backend.global.exception.BusinessLogicException;
-import edonymyeon.backend.global.exception.ExceptionInformation;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
+import edonymyeon.backend.member.application.dto.MemberId;
+import jakarta.servlet.http.HttpSession;
 import java.net.URI;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,25 +33,30 @@ public class AuthController {
 
     private final KakaoAuthResponseProvider kakaoAuthResponseProvider;
 
-    private final TokenGenerator tokenGenerator;
-
     @PostMapping("/login")
-    public ResponseEntity<Void> login(@RequestBody LoginRequest loginRequest) {
-        authService.login(loginRequest);
-        final String basicToken = tokenGenerator.getToken(loginRequest.email());
+    public ResponseEntity<Void> login(@RequestBody LoginRequest loginRequest,
+                                      HttpSession session) {
+        final MemberId member = authService.login(loginRequest);
+        registerSession(session, member);
         return ResponseEntity.ok()
-                .header(HttpHeaders.AUTHORIZATION, basicToken)
+                .location(URI.create("/"))
                 .build();
     }
 
+    private void registerSession(final HttpSession session, final MemberId member) {
+        session.setAttribute(USER.getSessionId(), member.id());
+        session.setMaxInactiveInterval(USER.getValidatedTime());
+    }
+
     @PostMapping("/auth/kakao/login")
-    public ResponseEntity<Void> loginWithKakao(@RequestBody KakaoLoginRequest loginRequest) {
+    public ResponseEntity<Void> loginWithKakao(@RequestBody KakaoLoginRequest loginRequest,
+                                               HttpSession session) {
         final KakaoLoginResponse kakaoLoginResponse = kakaoAuthResponseProvider.request(loginRequest);
 
-        final MemberResponse memberResponse = authService.loginByKakao(kakaoLoginResponse, loginRequest.deviceToken());
-        final String basicToken = tokenGenerator.getToken(memberResponse.email());
+        final MemberId member = authService.loginByKakao(kakaoLoginResponse, loginRequest.deviceToken());
+        registerSession(session, member);
         return ResponseEntity.ok()
-                .header(HttpHeaders.AUTHORIZATION, basicToken)
+                .location(URI.create("/"))
                 .build();
     }
 
@@ -71,14 +74,10 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(@RequestBody LogoutRequest logoutRequest, HttpServletRequest request) {
-        try {
-            request.logout();
-        } catch (ServletException e) {
-            log.error("로그아웃 실패", e);
-            throw new BusinessLogicException(ExceptionInformation.LOGOUT_FAILED);
+    public ResponseEntity<Void> logout(@RequestBody LogoutRequest logoutRequest, HttpSession session) {
+        if (Objects.nonNull(session)) {
+            session.invalidate();
         }
-
         authService.logout(logoutRequest.deviceToken());
         return ResponseEntity.ok().build();
     }

--- a/backend/src/main/java/edonymyeon/backend/auth/ui/AuthController.java
+++ b/backend/src/main/java/edonymyeon/backend/auth/ui/AuthController.java
@@ -2,6 +2,7 @@ package edonymyeon.backend.auth.ui;
 
 import static edonymyeon.backend.auth.ui.SessionConst.USER;
 
+import edonymyeon.backend.auth.annotation.AuthPrincipal;
 import edonymyeon.backend.auth.application.AuthService;
 import edonymyeon.backend.auth.application.KakaoAuthResponseProvider;
 import edonymyeon.backend.auth.application.dto.DuplicateCheckResponse;
@@ -17,6 +18,7 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -71,6 +73,13 @@ public class AuthController {
     public ResponseEntity<Void> join(@RequestBody JoinRequest joinRequest) {
         authService.joinMember(joinRequest);
         return ResponseEntity.created(URI.create("/login")).build();
+    }
+
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<Void> withdraw(@AuthPrincipal MemberId memberId) {
+        authService.deleteMember(memberId);
+        return ResponseEntity.noContent()
+                .build();
     }
 
     @PostMapping("/logout")

--- a/backend/src/main/java/edonymyeon/backend/auth/ui/SessionConst.java
+++ b/backend/src/main/java/edonymyeon/backend/auth/ui/SessionConst.java
@@ -1,0 +1,22 @@
+package edonymyeon.backend.auth.ui;
+
+public enum SessionConst {
+
+    USER("userId", 30 * 60);
+
+    private final String sessionId;
+    private final int validatedTime;
+
+    SessionConst(final String sessionId, final int validatedTime) {
+        this.sessionId = sessionId;
+        this.validatedTime = validatedTime;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public int getValidatedTime() {
+        return validatedTime;
+    }
+}

--- a/backend/src/main/java/edonymyeon/backend/auth/ui/argumentresolver/AuthArgumentResolver.java
+++ b/backend/src/main/java/edonymyeon/backend/auth/ui/argumentresolver/AuthArgumentResolver.java
@@ -1,17 +1,18 @@
 package edonymyeon.backend.auth.ui.argumentresolver;
 
+import static edonymyeon.backend.auth.ui.SessionConst.USER;
 import static edonymyeon.backend.global.exception.ExceptionInformation.AUTHORIZATION_EMPTY;
 
 import edonymyeon.backend.auth.annotation.AuthPrincipal;
-import edonymyeon.backend.auth.application.AuthService;
 import edonymyeon.backend.global.exception.EdonymyeonException;
+import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.application.dto.AnonymousMemberId;
 import edonymyeon.backend.member.application.dto.MemberId;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import org.apache.tomcat.util.codec.binary.Base64;
 import org.springframework.core.MethodParameter;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -21,8 +22,6 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @RequiredArgsConstructor
 @Component
 public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
-
-    private final AuthService authService;
 
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {
@@ -37,32 +36,31 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
             final NativeWebRequest webRequest,
             final WebDataBinderFactory binderFactory
     ) {
-        String authorization = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
-        if (authorization == null) {
+        final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        final HttpSession session = request.getSession();
+
+        if (Objects.isNull(session)) {
             if (!Objects.requireNonNull(parameter.getParameterAnnotation(AuthPrincipal.class)).required()) {
                 return new AnonymousMemberId();
             }
             throw new EdonymyeonException(AUTHORIZATION_EMPTY);
         }
 
-        final String email = parseToEmail(authorization);
+        final Long userId = getUserId(session);
 
-        if (Objects.isNull(email)) {
+        if (Objects.isNull(userId)) {
             throw new EdonymyeonException(AUTHORIZATION_EMPTY);
         }
 
-        return authService.getAuthenticatedUser(email);
+        session.setMaxInactiveInterval(USER.getValidatedTime());
+        return new ActiveMemberId(userId);
     }
 
-    private String parseToEmail(final String authorization) {
-        String[] authHeader = authorization.split(" ");
-        if (!authHeader[0].equalsIgnoreCase("basic")) {
+    private Long getUserId(final HttpSession session) {
+        try {
+            return (Long) session.getAttribute(USER.getSessionId());
+        } catch (IllegalStateException e) {
             throw new EdonymyeonException(AUTHORIZATION_EMPTY);
         }
-
-        String decodedString = new String(Base64.decodeBase64(authHeader[1]));
-
-        String[] credentials = decodedString.split(":");
-        return credentials[0];
     }
 }

--- a/backend/src/main/java/edonymyeon/backend/image/profileimage/application/ProfileImageEventListener.java
+++ b/backend/src/main/java/edonymyeon/backend/image/profileimage/application/ProfileImageEventListener.java
@@ -1,0 +1,21 @@
+package edonymyeon.backend.image.profileimage.application;
+
+import edonymyeon.backend.image.ImageFileUploader;
+import edonymyeon.backend.member.application.event.ProfileImageDeletionEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class ProfileImageEventListener {
+
+    private final ImageFileUploader imageFileUploader;
+
+    @Async
+    @TransactionalEventListener
+    public void removeFile(ProfileImageDeletionEvent event) {
+        imageFileUploader.removeFile(event.imageInfo());
+    }
+}

--- a/backend/src/main/java/edonymyeon/backend/member/application/MemberService.java
+++ b/backend/src/main/java/edonymyeon/backend/member/application/MemberService.java
@@ -3,19 +3,20 @@ package edonymyeon.backend.member.application;
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_ID_NOT_FOUND;
 
 import edonymyeon.backend.global.exception.EdonymyeonException;
-import edonymyeon.backend.image.ImageFileUploader;
 import edonymyeon.backend.image.profileimage.repository.ProfileImageInfoRepository;
 import edonymyeon.backend.member.application.dto.MemberId;
 import edonymyeon.backend.member.application.dto.YearMonthDto;
 import edonymyeon.backend.member.application.dto.request.PurchaseConfirmRequest;
 import edonymyeon.backend.member.application.dto.request.SavingConfirmRequest;
 import edonymyeon.backend.member.application.dto.response.MyPageResponse;
+import edonymyeon.backend.member.application.event.ProfileImageDeletionEvent;
 import edonymyeon.backend.member.domain.Device;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.repository.MemberRepository;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,7 +34,7 @@ public class MemberService {
 
     private final ProfileImageInfoRepository profileImageInfoRepository;
 
-    private final ImageFileUploader imageFileUploader;
+    private final ApplicationEventPublisher publisher;
 
     public MyPageResponse findMemberInfoById(final Long id) {
         final Member member = memberRepository.findById(id)
@@ -42,17 +43,11 @@ public class MemberService {
     }
 
     @Transactional
-    public void deleteMember(final Long id) {
-        final Member member = memberRepository.findById(id)
-                .orElseThrow(() -> new EdonymyeonException(MEMBER_ID_NOT_FOUND));
-
+    public void deleteProfileImage(final Member member) {
         if (Objects.nonNull(member.getProfileImageInfo())) {
             profileImageInfoRepository.delete(member.getProfileImageInfo());
-            imageFileUploader.removeFile(member.getProfileImageInfo());
+            publisher.publishEvent(new ProfileImageDeletionEvent(member.getProfileImageInfo()));
         }
-
-        member.withdraw();
-        memberRepository.save(member);
     }
 
     @Transactional

--- a/backend/src/main/java/edonymyeon/backend/member/application/event/ProfileImageDeletionEvent.java
+++ b/backend/src/main/java/edonymyeon/backend/member/application/event/ProfileImageDeletionEvent.java
@@ -1,0 +1,7 @@
+package edonymyeon.backend.member.application.event;
+
+import edonymyeon.backend.image.domain.ImageInfo;
+
+public record ProfileImageDeletionEvent(ImageInfo imageInfo) {
+
+}

--- a/backend/src/main/java/edonymyeon/backend/member/ui/MemberController.java
+++ b/backend/src/main/java/edonymyeon/backend/member/ui/MemberController.java
@@ -21,13 +21,6 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @DeleteMapping("/withdraw")
-    public ResponseEntity<Void> withdraw(@AuthPrincipal MemberId memberId) {
-        memberService.deleteMember(memberId.id());
-        return ResponseEntity.noContent()
-                .build();
-    }
-
     @GetMapping("/profile")
     public ResponseEntity<MyPageResponse> findMemberInfo(@AuthPrincipal MemberId memberId) {
         final MyPageResponse memberInfo = memberService.findMemberInfoById(memberId.id());

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.profiles.active=prod
+
+server.servlet.session.cookie.same-site=none
+server.servlet.session.cookie.secure=true

--- a/backend/src/test/java/edonymyeon/backend/auth/application/AuthDeleteServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/auth/application/AuthDeleteServiceTest.java
@@ -3,10 +3,11 @@ package edonymyeon.backend.auth.application;
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_IS_DELETED;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import edonymyeon.backend.auth.application.dto.LoginRequest;
 import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.member.domain.Member;
-import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.support.IntegrationTest;
+import edonymyeon.backend.support.TestMemberBuilder;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -33,13 +34,13 @@ class AuthDeleteServiceTest {
                 .builder()
                 .id(1L)
                 .email("test@email.com")
-                .password("passwrod1234!")
                 .nickname("null")
                 .deleted(true)
                 .build();
 
-        final String email = member.getEmail();
-        assertThatThrownBy(() -> authService.getAuthenticatedUser(email))
+        final LoginRequest request = new LoginRequest(member.getEmail(), TestMemberBuilder.getRawPassword(),
+                "");
+        assertThatThrownBy(() -> authService.login(request))
                 .isInstanceOf(EdonymyeonException.class)
                 .hasMessage(MEMBER_IS_DELETED.getMessage());
     }

--- a/backend/src/test/java/edonymyeon/backend/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/auth/application/AuthServiceTest.java
@@ -6,7 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -17,13 +21,19 @@ import edonymyeon.backend.auth.application.dto.KakaoLoginResponse;
 import edonymyeon.backend.auth.application.dto.LoginRequest;
 import edonymyeon.backend.auth.application.dto.LogoutRequest;
 import edonymyeon.backend.auth.domain.PasswordEncoder;
+import edonymyeon.backend.image.ImageFileUploader;
+import edonymyeon.backend.image.profileimage.domain.ProfileImageInfo;
 import edonymyeon.backend.member.application.MemberService;
+import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.domain.SocialInfo;
+import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.setting.application.SettingService;
 import edonymyeon.backend.support.IntegrationTest;
 import jakarta.persistence.EntityManager;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -31,6 +41,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -55,6 +66,12 @@ class AuthServiceTest {
 
     @SpyBean
     private PasswordEncoder passwordEncoder;
+
+    @SpyBean
+    private MemberRepository memberRepository;
+
+    @MockBean
+    private ImageFileUploader uploader;
 
     @Test
     void 회원가입시_사용한_디바이스_정보를_함께_저장한다(@Autowired EntityManager entityManager) {
@@ -139,5 +156,52 @@ class AuthServiceTest {
             verify(passwordEncoder, atLeastOnce()).encode(any());
             verify(passwordEncoder, atLeastOnce()).matches(any(), any());
         });
+    }
+
+    @Test
+    void 회원_삭제의_트랜잭션이_커밋되면_프로필_이미지를_물리적으로_삭제한다() {
+        // given
+        final JoinRequest request = new JoinRequest("example@email.com", "password1234!", "nickname", "");
+        final Member member = authService.joinMember(request);
+
+        final Member mockedMember = mock(Member.class);
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(mockedMember));
+        when(mockedMember.getProfileImageInfo()).thenReturn(new ProfileImageInfo("storeName"));
+
+        // when
+        final ActiveMemberId memberId = new ActiveMemberId(member.getId());
+        authService.deleteMember(memberId);
+
+        // then
+        SoftAssertions.assertSoftly(
+                soft -> {
+                    verify(memberService, atLeastOnce()).deleteProfileImage(mockedMember);
+                    verify(uploader, atLeastOnce()).removeFile(any());
+                }
+        );
+    }
+
+    @Test
+    void 회원_삭제의_트랜잭션이_롤백되면_프로필_이미지를_물리적으로_삭제하지않는다() {
+        // given
+        final var request = new JoinRequest("example@email.com", "password1234!", "nickname", "");
+        final var member = authService.joinMember(request);
+
+        final var mockedMember = mock(Member.class);
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(mockedMember));
+        when(mockedMember.getProfileImageInfo()).thenReturn(new ProfileImageInfo("storeName"));
+        doThrow(new RuntimeException("롤백용 예외")).when(mockedMember).withdraw();
+
+        // when
+        final ActiveMemberId memberId = new ActiveMemberId(member.getId());
+
+        // then
+        SoftAssertions.assertSoftly(
+                soft -> {
+                    soft.assertThatThrownBy(() -> authService.deleteMember(memberId));
+                    verify(memberService, atLeastOnce()).deleteProfileImage(mockedMember);
+                    verify(uploader, never()).removeFile(any());
+                }
+        );
     }
 }

--- a/backend/src/test/java/edonymyeon/backend/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/auth/application/AuthServiceTest.java
@@ -16,7 +16,6 @@ import edonymyeon.backend.auth.application.dto.JoinRequest;
 import edonymyeon.backend.auth.application.dto.KakaoLoginResponse;
 import edonymyeon.backend.auth.application.dto.LoginRequest;
 import edonymyeon.backend.auth.application.dto.LogoutRequest;
-import edonymyeon.backend.auth.application.dto.MemberResponse;
 import edonymyeon.backend.auth.domain.PasswordEncoder;
 import edonymyeon.backend.member.application.MemberService;
 import edonymyeon.backend.member.domain.Member;
@@ -139,20 +138,6 @@ class AuthServiceTest {
             assertDoesNotThrow(() -> authService.login(loginRequest));
             verify(passwordEncoder, atLeastOnce()).encode(any());
             verify(passwordEncoder, atLeastOnce()).matches(any(), any());
-        });
-    }
-
-    @Test
-    void 카카오_로그인시_DB에_암호화된_비밀번호와_입력받은_비밀번호를_검증한다() {
-        final SocialInfo socialInfo = SocialInfo.of(SocialInfo.SocialType.KAKAO, 1L);
-        final Member member = authService.joinSocialMember(socialInfo);
-
-        final KakaoLoginResponse kakaoLoginResponse = new KakaoLoginResponse(socialInfo.getSocialId());
-        final MemberResponse memberResponse = authService.loginByKakao(kakaoLoginResponse, "");
-
-        assertSoftly(soft -> {
-            soft.assertThat(member.getEmail()).isEqualTo(memberResponse.email());
-            soft.assertThat(member.getPassword()).isEqualTo(memberResponse.password());
         });
     }
 }

--- a/backend/src/test/java/edonymyeon/backend/auth/docs/AuthControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/auth/docs/AuthControllerDocsTest.java
@@ -25,7 +25,7 @@ import edonymyeon.backend.auth.application.dto.JoinRequest;
 import edonymyeon.backend.auth.application.dto.KakaoLoginRequest;
 import edonymyeon.backend.auth.application.dto.KakaoLoginResponse;
 import edonymyeon.backend.auth.application.dto.LoginRequest;
-import edonymyeon.backend.auth.application.dto.MemberResponse;
+import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.support.DocsTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -38,7 +38,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 @SuppressWarnings("NonAsciiCharacters")
-public class AuthControllerDocsTest extends DocsTest {
+class AuthControllerDocsTest extends DocsTest {
 
     @MockBean
     private AuthService authService;
@@ -86,10 +86,10 @@ public class AuthControllerDocsTest extends DocsTest {
     void 카카오_로그인_문서화() throws Exception {
         final KakaoLoginRequest kakaoLoginRequest = new KakaoLoginRequest("accessToken!!!!!", "deviceToken");
         final KakaoLoginResponse kakaoLoginResponse = new KakaoLoginResponse(1L);
-        final MemberResponse memberResponse = new MemberResponse("example@email.com", "password123!");
+        final ActiveMemberId activeMemberId = new ActiveMemberId(1L);
 
         when(kakaoAuthResponseProvider.request(kakaoLoginRequest)).thenReturn(kakaoLoginResponse);
-        when(authService.loginByKakao(kakaoLoginResponse, kakaoLoginRequest.deviceToken())).thenReturn(memberResponse);
+        when(authService.loginByKakao(kakaoLoginResponse, kakaoLoginRequest.deviceToken())).thenReturn(activeMemberId);
 
         final MockHttpServletRequestBuilder 로그인_요청 = post("/auth/kakao/login")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/edonymyeon/backend/auth/docs/AuthControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/auth/docs/AuthControllerDocsTest.java
@@ -1,12 +1,7 @@
 package edonymyeon.backend.auth.docs;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
@@ -15,6 +10,8 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,7 +27,6 @@ import edonymyeon.backend.support.DocsTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.headers.HeaderDescriptor;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.request.ParameterDescriptor;
@@ -53,9 +49,13 @@ class AuthControllerDocsTest extends DocsTest {
 
     @Test
     void 로그인_문서화() throws Exception {
-        final LoginRequest request = new LoginRequest("example@example.com", "password1234!", "kj234jkn342kj");
+        final String email = "example@example.com";
+        final String password = "password1234!";
+        final String deviceToken = "deviceToken";
 
-        when(authService.login(request)).thenReturn(any());
+        final LoginRequest request = new LoginRequest(email, password, deviceToken);
+
+        when(authService.login(request)).thenReturn(new ActiveMemberId(1L));
 
         final MockHttpServletRequestBuilder 로그인_요청 = post("/login")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -67,14 +67,9 @@ class AuthControllerDocsTest extends DocsTest {
                 fieldWithPath("deviceToken").description("로그인시 사용한 디바이스 토큰")
         };
 
-        final HeaderDescriptor[] 응답_헤더 = {
-                headerWithName("Authorization").description("basic Auth 토큰 값")
-        };
-
         final RestDocumentationResultHandler 문서화 = document("login",
                 preprocessRequest(prettyPrint()),
-                requestFields(로그인_요청_파라미터),
-                responseHeaders(응답_헤더)
+                requestFields(로그인_요청_파라미터)
         );
 
         mockMvc.perform(로그인_요청)
@@ -100,14 +95,9 @@ class AuthControllerDocsTest extends DocsTest {
                 fieldWithPath("deviceToken").description("로그인 시 사용한 디바이스의 식별자")
         };
 
-        final HeaderDescriptor[] 응답_헤더 = {
-                headerWithName("Authorization").description("basic Auth 토큰 값")
-        };
-
         final RestDocumentationResultHandler 문서화 = document("kakao-login",
                 preprocessRequest(prettyPrint()),
-                requestFields(로그인_요청_파라미터),
-                responseHeaders(응답_헤더)
+                requestFields(로그인_요청_파라미터)
         );
 
         mockMvc.perform(로그인_요청)

--- a/backend/src/test/java/edonymyeon/backend/comment/docs/CommentControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/comment/docs/CommentControllerDocsTest.java
@@ -1,11 +1,10 @@
 package edonymyeon.backend.comment.docs;
 
+import static edonymyeon.backend.auth.ui.SessionConst.USER;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -39,7 +38,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.mock.web.MockPart;
@@ -74,16 +72,11 @@ public class CommentControllerDocsTest {
                 .part(내용)
                 .file(이미지)
                 .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, "Basic "
-                        + java.util.Base64.getEncoder()
-                        .encodeToString((사용자.getEmail() + ":" + 사용자.getPassword()).getBytes()));
+                .sessionAttr(USER.getSessionId(), 사용자.getId());
 
         final RestDocumentationResultHandler 문서화 = document("comment-create",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
-                requestHeaders(
-                        headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
-                ),
                 pathParameters(
                         parameterWithName("postId").description("게시글 id")
                 ),
@@ -106,14 +99,9 @@ public class CommentControllerDocsTest {
 
         final MockHttpServletRequestBuilder 댓글_삭제_요청 = delete("/posts/{postId}/comments/{commentId}", 1L, 1L)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, "Basic "
-                        + java.util.Base64.getEncoder()
-                        .encodeToString((사용자.getEmail() + ":" + 사용자.getPassword()).getBytes()));
+                .sessionAttr(USER.getSessionId(), 사용자.getId());
 
         final RestDocumentationResultHandler 문서화 = document("comment-delete",
-                requestHeaders(
-                        headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
-                ),
                 pathParameters(
                         parameterWithName("postId").description("게시글 id"),
                         parameterWithName("commentId").description("댓글 id")

--- a/backend/src/test/java/edonymyeon/backend/consumption/docs/ConsumptionControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/consumption/docs/ConsumptionControllerDocsTest.java
@@ -1,5 +1,18 @@
 package edonymyeon.backend.consumption.docs;
 
+import static edonymyeon.backend.auth.ui.SessionConst.USER;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edonymyeon.backend.consumption.application.ConsumptionService;
 import edonymyeon.backend.consumption.application.dto.ConsumptionPriceResponse;
@@ -8,29 +21,13 @@ import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.support.DocsTest;
 import edonymyeon.backend.support.TestMemberBuilder;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpHeaders;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-
-import java.util.List;
-import java.util.Optional;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class ConsumptionControllerDocsTest extends DocsTest {
@@ -59,6 +56,7 @@ public class ConsumptionControllerDocsTest extends DocsTest {
     @Test
     void 특정기간의_소비금액을_확인한다() throws Exception {
         final Member 회원 = testMemberBuilder.builder()
+                .id(1L)
                 .buildWithoutSaving();
         final RecentConsumptionsResponse response = new RecentConsumptionsResponse(
                 "2023-08",
@@ -73,15 +71,10 @@ public class ConsumptionControllerDocsTest extends DocsTest {
         소비_서비스를_모킹한다(response);
 
         final MockHttpServletRequestBuilder 최근_소비_조회_요청 = get("/consumptions?period-month={periodMonth}", 1)
-                .header(HttpHeaders.AUTHORIZATION, "Basic "
-                        + java.util.Base64.getEncoder()
-                        .encodeToString((회원.getEmail() + ":" + 회원.getPassword()).getBytes()));
+                .sessionAttr(USER.getSessionId(), 회원.getId());
 
         final RestDocumentationResultHandler 문서화 = document("recent-consumptions",
                 preprocessResponse(prettyPrint()),
-                requestHeaders(
-                        headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
-                ),
                 queryParameters(
                         parameterWithName("period-month").description("조회 기간 ex) 1, 6")
                 ),

--- a/backend/src/test/java/edonymyeon/backend/image/ImageFileSizeIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/image/ImageFileSizeIntegrationTest.java
@@ -23,12 +23,13 @@ public class ImageFileSizeIntegrationTest extends IntegrationFixture implements 
     @Test
     void 이미지_파일_하나의_용량이_20MB_이하면_성공한다() {
         final Member 작성자 = memberTestSupport.builder().build();
+        final String sessionId = 로그인(작성자);
         final var 게시글_생성_응답 = RestAssured.given()
                 .multiPart("title", "this is title")
                 .multiPart("content", "this is content")
                 .multiPart("price", 1000)
                 .multiPart("newImages", 크기_20MB_이미지, MediaType.IMAGE_JPEG_VALUE)
-                .auth().preemptive().basic(작성자.getEmail(), 작성자.getPassword())
+                .sessionId(sessionId)
                 .when()
                 .post("/posts")
                 .then()
@@ -40,12 +41,14 @@ public class ImageFileSizeIntegrationTest extends IntegrationFixture implements 
     @Test
     void 이미지_파일_하나의_용량이_20MB를_보다_크면_실패한다() {
         final Member 작성자 = memberTestSupport.builder().build();
+        final String sessionId = 로그인(작성자);
+
         final var 게시글_생성_응답 = RestAssured.given()
                 .multiPart("title", "this is title")
                 .multiPart("content", "this is content")
                 .multiPart("price", 1000)
                 .multiPart("newImages", 크기_21MB_이미지, MediaType.IMAGE_JPEG_VALUE)
-                .auth().preemptive().basic(작성자.getEmail(), 작성자.getPassword())
+                .sessionId(sessionId)
                 .when()
                 .post("/posts")
                 .then()
@@ -64,6 +67,9 @@ public class ImageFileSizeIntegrationTest extends IntegrationFixture implements 
     @Test
     void 요청의_크기가_200MB_이하면_성공한다() {
         final Member 작성자 = memberTestSupport.builder().build();
+
+        final String sessionId = 로그인(작성자);
+
         final var 게시글_생성_응답 = RestAssured.given()
                 .multiPart("title", "this is title")
                 .multiPart("content", "this is content")
@@ -78,7 +84,7 @@ public class ImageFileSizeIntegrationTest extends IntegrationFixture implements 
                 .multiPart("newImages", 크기_20MB_이미지, MediaType.IMAGE_JPEG_VALUE)
                 .multiPart("newImages", 크기_20MB_이미지, MediaType.IMAGE_JPEG_VALUE)
                 .multiPart("newImages", 크기_20MB_이미지, MediaType.IMAGE_JPEG_VALUE)
-                .auth().preemptive().basic(작성자.getEmail(), 작성자.getPassword())
+                .sessionId(sessionId)
                 .when()
                 .post("/posts")
                 .then()

--- a/backend/src/test/java/edonymyeon/backend/member/docs/MemberControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/member/docs/MemberControllerDocsTest.java
@@ -1,5 +1,21 @@
 package edonymyeon.backend.member.docs;
 
+import static edonymyeon.backend.auth.ui.SessionConst.USER;
+import static edonymyeon.backend.consumption.domain.ConsumptionType.SAVING;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edonymyeon.backend.consumption.domain.Consumption;
 import edonymyeon.backend.consumption.repository.ConsumptionRepository;
@@ -11,33 +27,13 @@ import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;
 import edonymyeon.backend.support.DocsTest;
 import edonymyeon.backend.support.TestMemberBuilder;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-
-import java.util.Base64;
-import java.util.Optional;
-
-import static edonymyeon.backend.consumption.domain.ConsumptionType.SAVING;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class MemberControllerDocsTest extends DocsTest {
@@ -78,6 +74,7 @@ public class MemberControllerDocsTest extends DocsTest {
     @Test
     void 구매_확정한다() throws Exception {
         final Member 회원 = testMemberBuilder.builder()
+                .id(1L)
                 .buildWithoutSaving();
         final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 회원);
         final Consumption 소비 = Consumption.of(게시글, SAVING, null, 2023, 7);
@@ -90,16 +87,11 @@ public class MemberControllerDocsTest extends DocsTest {
 
         final MockHttpServletRequestBuilder 구매_확정_요청 = post("/profile/my-posts/{postId}/purchase-confirm", 게시글.getId())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, "Basic "
-                        + java.util.Base64.getEncoder()
-                        .encodeToString((회원.getEmail() + ":" + 회원.getPassword()).getBytes()))
+                .sessionAttr(USER.getSessionId(), 회원.getId())
                 .content(objectMapper.writeValueAsString(request));
 
         final RestDocumentationResultHandler 문서화 = document("purchase-confirm",
                 preprocessRequest(prettyPrint()),
-                requestHeaders(
-                        headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
-                ),
                 pathParameters(
                         parameterWithName("postId").description("게시글 id")
                 ),
@@ -117,7 +109,7 @@ public class MemberControllerDocsTest extends DocsTest {
 
     @Test
     void 절약_확정한다() throws Exception {
-        final Member 회원 = testMemberBuilder.builder().buildWithoutSaving();
+        final Member 회원 = testMemberBuilder.builder().id(1L).buildWithoutSaving();
         final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 회원);
         final Consumption 소비 = Consumption.of(게시글, SAVING, null, 2023, 7);
 
@@ -129,16 +121,11 @@ public class MemberControllerDocsTest extends DocsTest {
 
         final MockHttpServletRequestBuilder 절약_확정_요청 = post("/profile/my-posts/{postId}/saving-confirm", 게시글.getId())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, "Basic "
-                        + java.util.Base64.getEncoder()
-                        .encodeToString((회원.getEmail() + ":" + 회원.getPassword()).getBytes()))
+                .sessionAttr(USER.getSessionId(), 회원.getId())
                 .content(objectMapper.writeValueAsString(request));
 
         final RestDocumentationResultHandler 문서화 = document("saving-confirm",
                 preprocessRequest(prettyPrint()),
-                requestHeaders(
-                        headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
-                ),
                 pathParameters(
                         parameterWithName("postId").description("게시글 id")
                 ),
@@ -155,7 +142,7 @@ public class MemberControllerDocsTest extends DocsTest {
 
     @Test
     void 확정을_취소한다() throws Exception {
-        final Member 회원 = testMemberBuilder.builder().buildWithoutSaving();
+        final Member 회원 = testMemberBuilder.builder().id(1L).buildWithoutSaving();
         final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 회원);
         final Consumption 소비 = Consumption.of(게시글, SAVING, null, 2023, 7);
 
@@ -165,14 +152,9 @@ public class MemberControllerDocsTest extends DocsTest {
 
         final MockHttpServletRequestBuilder 확정_취소_요청 = delete("/profile/my-posts/{postId}/confirm-remove", 게시글.getId())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, "Basic "
-                        + java.util.Base64.getEncoder()
-                        .encodeToString((회원.getEmail() + ":" + 회원.getPassword()).getBytes()));
+                .sessionAttr(USER.getSessionId(), 회원.getId());
 
         final RestDocumentationResultHandler 문서화 = document("confirm-remove",
-                requestHeaders(
-                        headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
-                ),
                 pathParameters(
                         parameterWithName("postId").description("게시글 id")
                 )
@@ -185,18 +167,14 @@ public class MemberControllerDocsTest extends DocsTest {
 
     @Test
     void 회원_탈퇴한다() throws Exception {
-        final Member 회원 = testMemberBuilder.builder().buildWithoutSaving();
+        final Member 회원 = testMemberBuilder.builder().id(1L).buildWithoutSaving();
         회원_레포지토리를_모킹한다(회원);
         when(memberRepository.findById(회원.getId())).thenReturn(Optional.of(회원));
 
         final MockHttpServletRequestBuilder 회원_탈퇴_요청 = delete("/withdraw")
-                .header(HttpHeaders.AUTHORIZATION, "Basic "
-                        + Base64.getEncoder()
-                        .encodeToString((회원.getEmail() + ":" + 회원.getPassword()).getBytes()));
+                .sessionAttr(USER.getSessionId(), 회원.getId());
 
-        final RestDocumentationResultHandler 문서화 = document("withdraw",
-                requestHeaders(
-                        headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")));
+        final RestDocumentationResultHandler 문서화 = document("withdraw");
 
         this.mockMvc.perform(회원_탈퇴_요청)
                 .andExpect(status().isNoContent())

--- a/backend/src/test/java/edonymyeon/backend/member/integration/MemberIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/member/integration/MemberIntegrationTest.java
@@ -29,9 +29,11 @@ public class MemberIntegrationTest extends IntegrationFixture {
         final Member member = memberTestSupport.builder()
                 .build();
 
+        final String sessionId = 로그인(member);
+
         final ExtractableResponse<Response> response = RestAssured
                 .given()
-                .auth().preemptive().basic(member.getEmail(), member.getPassword())
+                .sessionId(sessionId)
                 .when()
                 .get("/profile")
                 .then()
@@ -69,9 +71,11 @@ public class MemberIntegrationTest extends IntegrationFixture {
                 .post(post2)
                 .build();
 
+        final String sessionId = 로그인(member);
+
         final ExtractableResponse<Response> response = RestAssured
                 .given()
-                .auth().preemptive().basic(member.getEmail(), member.getPassword())
+                .sessionId(sessionId)
                 .when()
                 .get("/profile/my-posts")
                 .then()
@@ -91,9 +95,11 @@ public class MemberIntegrationTest extends IntegrationFixture {
         final Member member = memberTestSupport.builder()
                 .build();
 
+        final String sessionId = 로그인(member);
+
         RestAssured
                 .given()
-                .auth().preemptive().basic(member.getEmail(), member.getPassword())
+                .sessionId(sessionId)
                 .when()
                 .delete("/withdraw");
 
@@ -128,9 +134,11 @@ public class MemberIntegrationTest extends IntegrationFixture {
                 .member(member)
                 .build();
 
+        final String sessionId = 로그인(member);
+
         RestAssured
                 .given()
-                .auth().preemptive().basic(member.getEmail(), member.getPassword())
+                .sessionId(sessionId)
                 .when()
                 .delete("/withdraw");
 

--- a/backend/src/test/java/edonymyeon/backend/notification/integration/NotificationIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/notification/integration/NotificationIntegrationTest.java
@@ -31,12 +31,13 @@ class NotificationIntegrationTest extends IntegrationFixture implements ImageFil
         final var 열람인 = 사용자를_하나_만든다();
         final var 열람인2 = 사용자를_하나_만든다();
         final var 게시글id = 응답의_location헤더에서_id를_추출한다(게시글을_하나_만든다(글쓴이));
+        final String sessionId = 로그인(글쓴이);
 
         thumbsService.thumbsUp(new ActiveMemberId(열람인.getId()), 게시글id);
         thumbsService.thumbsDown(new ActiveMemberId(열람인2.getId()), 게시글id);
 
         final var 알림목록_조회결과 = RestAssured.given()
-                .auth().preemptive().basic(글쓴이.getEmail(), 글쓴이.getPassword())
+                .sessionId(sessionId)
                 .when()
                 .get("/notification")
                 .then()

--- a/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/application/PostServiceTest.java
@@ -1,5 +1,9 @@
 package edonymyeon.backend.post.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
 import edonymyeon.backend.TestConfig;
 import edonymyeon.backend.consumption.repository.ConsumptionRepository;
 import edonymyeon.backend.global.exception.EdonymyeonException;
@@ -23,6 +27,12 @@ import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.support.MockMultipartFileTestSupport;
 import edonymyeon.backend.support.TestMemberBuilder;
 import jakarta.persistence.EntityManager;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,17 +42,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.regex.Pattern;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @SuppressWarnings("NonAsciiCharacters")
 @RequiredArgsConstructor
@@ -196,7 +195,8 @@ class PostServiceTest implements ImageFileCleaner {
     class 게시글을_삭제할_때 {
 
         @Test
-        void 연관된_소비내역도_삭제된다(@Autowired PostRepository postRepository, @Autowired ConsumptionRepository consumptionRepository) throws IOException {
+        void 연관된_소비내역도_삭제된다(@Autowired PostRepository postRepository,
+                            @Autowired ConsumptionRepository consumptionRepository) throws IOException {
             final PostIdResponse postIdResponse = postService.createPost(memberId, getPostRequest());
             final Post post = postRepository.findById(postIdResponse.id()).get();
 
@@ -235,7 +235,6 @@ class PostServiceTest implements ImageFileCleaner {
             // when
             Member 다른_사람 = memberTestSupport.builder()
                     .email("otheremail")
-                    .password("password123!")
                     .build();
 
             memberId = new ActiveMemberId(다른_사람.getId());

--- a/backend/src/test/java/edonymyeon/backend/post/docs/MyPostControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/docs/MyPostControllerDocsTest.java
@@ -1,5 +1,18 @@
 package edonymyeon.backend.post.docs;
 
+import static edonymyeon.backend.auth.ui.SessionConst.USER;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edonymyeon.backend.image.domain.Domain;
 import edonymyeon.backend.image.postimage.domain.PostImageInfos;
@@ -13,35 +26,18 @@ import edonymyeon.backend.post.application.dto.response.PostConsumptionResponse;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.support.DocsTest;
 import edonymyeon.backend.support.TestMemberBuilder;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
-import org.springframework.http.HttpHeaders;
-import org.springframework.restdocs.headers.HeaderDescriptor;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.request.ParameterDescriptor;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-
-import java.util.List;
-import java.util.Optional;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class MyPostControllerDocsTest extends DocsTest {
@@ -69,6 +65,7 @@ public class MyPostControllerDocsTest extends DocsTest {
         final GeneralFindingCondition findingCondition = GeneralFindingCondition.builder().build();
 
         final Member 회원 = testMemberBuilder.builder()
+                .id(1L)
                 .buildWithoutSaving();
         회원_레포지토리를_모킹한다(회원);
 
@@ -85,17 +82,11 @@ public class MyPostControllerDocsTest extends DocsTest {
         when(myPostService.findMyPosts(any(), any())).thenReturn(PostSlice.from(result));
 
         final MockHttpServletRequestBuilder 내_게시글_조회_요청 = get("/profile/my-posts")
-                .header(HttpHeaders.AUTHORIZATION, "Basic "
-                        + java.util.Base64.getEncoder()
-                        .encodeToString((회원.getEmail() + ":" + 회원.getPassword()).getBytes()))
+                .sessionAttr(USER.getSessionId(), 회원.getId())
                 .queryParam("page", findingCondition.getPage().toString())
                 .queryParam("size", findingCondition.getSize().toString())
                 .queryParam("sort-by", findingCondition.getSortBy().getName())
                 .queryParam("sort-direction", findingCondition.getSortDirection().name());
-
-        HeaderDescriptor[] 요청_헤더 = new HeaderDescriptor[]{
-                headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
-        };
 
         ParameterDescriptor[] 요청_쿼리_파라미터 = {
                 parameterWithName("page")
@@ -128,7 +119,6 @@ public class MyPostControllerDocsTest extends DocsTest {
 
         final RestDocumentationResultHandler 문서화 = document("my-posts",
                 preprocessResponse(prettyPrint()),
-                requestHeaders(요청_헤더),
                 queryParameters(요청_쿼리_파라미터),
                 responseFields(응답)
         );

--- a/backend/src/test/java/edonymyeon/backend/post/docs/PostControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/docs/PostControllerDocsTest.java
@@ -1,5 +1,26 @@
 package edonymyeon.backend.post.docs;
 
+import static edonymyeon.backend.auth.ui.SessionConst.USER;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import edonymyeon.backend.CacheConfig;
 import edonymyeon.backend.image.postimage.domain.PostImageInfo;
 import edonymyeon.backend.image.postimage.domain.PostImageInfos;
@@ -18,6 +39,10 @@ import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.thumbs.application.PostThumbsServiceImpl;
 import jakarta.servlet.http.Part;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.apache.http.entity.ContentType;
 import org.junit.jupiter.api.Test;
@@ -38,25 +63,6 @@ import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-
-import java.nio.charset.StandardCharsets;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SuppressWarnings("NonAsciiCharacters")
 @RequiredArgsConstructor
@@ -152,9 +158,8 @@ public class PostControllerDocsTest implements ImageFileCleaner {
                 .part(유지하는_이미지)
                 .file(추가되는_이미지)
                 .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, "Basic "
-                        + java.util.Base64.getEncoder()
-                        .encodeToString((글쓴이.getEmail() + ":" + 글쓴이.getPassword()).getBytes()));
+                .sessionAttr(USER.getSessionId(), 글쓴이.getId());
+
         게시글_수정_요청.with(request -> {
             request.setMethod(HttpMethod.PUT.name());
             return request;
@@ -162,9 +167,6 @@ public class PostControllerDocsTest implements ImageFileCleaner {
 
         final RestDocumentationResultHandler 문서화 = document("post-update",
                 preprocessResponse(prettyPrint()),
-                requestHeaders(
-                        headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
-                ),
                 pathParameters(
                         parameterWithName("postId").description("게시글 id")
                 ),
@@ -199,14 +201,9 @@ public class PostControllerDocsTest implements ImageFileCleaner {
 
         final MockHttpServletRequestBuilder 게시글_삭제_요청 = delete("/posts/{postId}", 게시글.getId())
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, "Basic "
-                        + java.util.Base64.getEncoder()
-                        .encodeToString((글쓴이.getEmail() + ":" + 글쓴이.getPassword()).getBytes()));
+                .sessionAttr(USER.getSessionId(), 글쓴이.getId());
 
         final RestDocumentationResultHandler 문서화 = document("post-delete",
-                requestHeaders(
-                        headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
-                ),
                 pathParameters(
                         parameterWithName("postId").description("게시글 id")
                 )

--- a/backend/src/test/java/edonymyeon/backend/post/docs/PostCreationDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/docs/PostCreationDocsTest.java
@@ -1,7 +1,6 @@
 package edonymyeon.backend.post.docs;
 
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static edonymyeon.backend.auth.ui.SessionConst.USER;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
@@ -14,10 +13,10 @@ import static org.springframework.restdocs.request.RequestDocumentation.requestP
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import edonymyeon.backend.support.TestMemberBuilder;
-import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.post.ImageFileCleaner;
+import edonymyeon.backend.support.IntegrationTest;
+import edonymyeon.backend.support.TestMemberBuilder;
 import jakarta.servlet.http.Part;
 import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +24,6 @@ import org.apache.http.entity.ContentType;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.mock.web.MockPart;
@@ -62,16 +60,11 @@ public class PostCreationDocsTest implements ImageFileCleaner {
                 .file(이미지)
                 .file(이미지)
                 .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, "Basic "
-                        + java.util.Base64.getEncoder()
-                        .encodeToString((글쓴이.getEmail() + ":" + 글쓴이.getPassword()).getBytes()));
+                .sessionAttr(USER.getSessionId(), 글쓴이.getId());
 
         final RestDocumentationResultHandler 문서화 = document("post-create",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
-                requestHeaders(
-                        headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
-                ),
                 requestParts(
                         partWithName("title").description("제목"),
                         partWithName("content").description("내용"),

--- a/backend/src/test/java/edonymyeon/backend/post/integration/PostCommentCountIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/integration/PostCommentCountIntegrationTest.java
@@ -182,10 +182,11 @@ public class PostCommentCountIntegrationTest extends IntegrationFixture {
         final Post 게시글1 = 댓글이_달린_게시글을_만든다(사용자, 10);
         final Post 게시글2 = 댓글이_달린_게시글을_만든다(사용자, 20);
 
+        final String sessionId = 로그인(사용자);
         final var 검색된_게시글_조회_결과 = RestAssured
                 .given()
+                .sessionId(sessionId)
                 .when()
-                .auth().preemptive().basic(사용자.getEmail(), 사용자.getPassword())
                 .get("/profile/my-posts")
                 .then()
                 .log().all()

--- a/backend/src/test/java/edonymyeon/backend/post/integration/PostIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/integration/PostIntegrationTest.java
@@ -61,12 +61,13 @@ public class PostIntegrationTest extends IntegrationFixture implements ImageFile
     @Test
     void 게시글을_작성할_때_내용은_0자_이상_가능하다() {
         final Member 작성자 = 사용자를_하나_만든다();
+        final String sessionId = 로그인(작성자);
         final var response = RestAssured.given()
                 .multiPart("title", "this is title")
                 .multiPart("content", "")
                 .multiPart("price", 1000)
                 .multiPart("images", 이미지1, MediaType.IMAGE_JPEG_VALUE)
-                .auth().preemptive().basic(작성자.getEmail(), 작성자.getPassword())
+                .sessionId(sessionId)
                 .when()
                 .post("/posts")
                 .then()
@@ -78,6 +79,8 @@ public class PostIntegrationTest extends IntegrationFixture implements ImageFile
     @Test
     void 게시글을_작성할때_이미지가_10개_이상이면_예외가_발생한다() {
         final Member 작성자 = 사용자를_하나_만든다();
+        final String sessionId = 로그인(작성자);
+
         final ExtractableResponse<Response> 게시글_작성_응답 = RestAssured.given()
                 .multiPart("title", "제목")
                 .multiPart("content", "내용")
@@ -94,7 +97,7 @@ public class PostIntegrationTest extends IntegrationFixture implements ImageFile
                 .multiPart("newImages", 이미지1)
                 .multiPart("newImages", 이미지1)
                 .when()
-                .auth().preemptive().basic(작성자.getEmail(), 작성자.getPassword())
+                .sessionId(sessionId)
                 .post("/posts")
                 .then()
                 .extract();
@@ -114,8 +117,10 @@ public class PostIntegrationTest extends IntegrationFixture implements ImageFile
         final ExtractableResponse<Response> 게시글_생성_응답 = 게시글을_하나_만든다(작성자);
         final long 게시글_id = 응답의_location헤더에서_id를_추출한다(게시글_생성_응답);
 
+        final String sessionId = 로그인(작성자);
+
         RestAssured.given()
-                .auth().preemptive().basic(작성자.getEmail(), 작성자.getPassword())
+                .sessionId(sessionId)
                 .when()
                 .delete("/posts/" + 게시글_id)
                 .then()
@@ -129,8 +134,9 @@ public class PostIntegrationTest extends IntegrationFixture implements ImageFile
         final long 게시글_id = 응답의_location헤더에서_id를_추출한다(게시글_생성_응답);
 
         final Member 작성자가_아닌_사람 = 사용자를_하나_만든다();
+        final String sessionId = 로그인(작성자가_아닌_사람);
         RestAssured.given()
-                .auth().preemptive().basic(작성자가_아닌_사람.getEmail(), 작성자가_아닌_사람.getPassword())
+                .sessionId(sessionId)
                 .when()
                 .delete("/posts/" + 게시글_id)
                 .then()
@@ -144,8 +150,12 @@ public class PostIntegrationTest extends IntegrationFixture implements ImageFile
         final ExtractableResponse<Response> 게시글_생성_응답 = 게시글을_하나_만든다(작성자);
         final long 게시글_id = 응답의_location헤더에서_id를_추출한다(게시글_생성_응답);
         final Member 추천하는_사람 = 사용자를_하나_만든다();
+
+        final String sessionId1 = 로그인(추천하는_사람);
+        final String sessionId2 = 로그인(작성자);
+
         RestAssured.given()
-                .auth().preemptive().basic(추천하는_사람.getEmail(), 추천하는_사람.getPassword())
+                .sessionId(sessionId1)
                 .when()
                 .put("posts/" + 게시글_id + "/up")
                 .then()
@@ -153,7 +163,7 @@ public class PostIntegrationTest extends IntegrationFixture implements ImageFile
 
         //when
         final ExtractableResponse<Response> 게시글_삭제_응답 = RestAssured.given()
-                .auth().preemptive().basic(작성자.getEmail(), 작성자.getPassword())
+                .sessionId(sessionId2)
                 .when()
                 .delete("posts/" + 게시글_id)
                 .then()
@@ -176,9 +186,10 @@ public class PostIntegrationTest extends IntegrationFixture implements ImageFile
         final PurchaseConfirmRequest 구매_확정_요청 = new PurchaseConfirmRequest(10000L, 2023, 7);
         MemberConsumptionSteps.구매_확정_요청을_보낸다(작성자, 게시글_id, 구매_확정_요청);
 
+        final String sessionId = 로그인(작성자);
         //when
         final ExtractableResponse<Response> 게시글_삭제_응답 = RestAssured.given()
-                .auth().preemptive().basic(작성자.getEmail(), 작성자.getPassword())
+                .sessionId(sessionId)
                 .when()
                 .delete("posts/" + 게시글_id)
                 .then()
@@ -443,14 +454,17 @@ public class PostIntegrationTest extends IntegrationFixture implements ImageFile
         final ExtractableResponse<Response> 게시글_상세_조회_응답 = 게시글_하나를_상세_조회한다(작성자, 게시글_id);
 
         final String 유지할_이미지의_url = 게시글_상세_조회_응답.body().jsonPath().getString("images[0]");
+
+        final String sessionId = 로그인(작성자);
+
         final ExtractableResponse<Response> 게시글_수정_응답 = RestAssured.given()
                 .multiPart("title", "제목을 수정하자")
                 .multiPart("content", "내용을 수정하자")
                 .multiPart("price", 10000)
                 .multiPart("originalImages", 유지할_이미지의_url)
                 .multiPart("newImages", 이미지1)
+                .sessionId(sessionId)
                 .when()
-                .auth().preemptive().basic(작성자.getEmail(), 작성자.getPassword())
                 .put("/posts/" + 게시글_id)
                 .then()
                 .extract();
@@ -468,15 +482,17 @@ public class PostIntegrationTest extends IntegrationFixture implements ImageFile
         final ExtractableResponse<Response> 게시글_상세_조회_응답 = 게시글_하나를_상세_조회한다(작성자, 게시글_id);
 
         final String 유지할_이미지의_url = 게시글_상세_조회_응답.body().jsonPath().getString("images[0]");
-        System.out.println("유지할_이미지의_url = " + 유지할_이미지의_url);
+
+        final String sessionId = 로그인(작성자가_아닌_사람);
+
         final ExtractableResponse<Response> 게시글_수정_응답 = RestAssured.given()
                 .multiPart("title", "제목을 수정하자")
                 .multiPart("content", "내용을 수정하자")
                 .multiPart("price", 10000)
                 .multiPart("originalImages", 유지할_이미지의_url)
                 .multiPart("newImages", 이미지1)
+                .sessionId(sessionId)
                 .when()
-                .auth().preemptive().basic(작성자가_아닌_사람.getEmail(), 작성자가_아닌_사람.getPassword())
                 .put("/posts/" + 게시글_id)
                 .then()
                 .extract();
@@ -501,9 +517,11 @@ public class PostIntegrationTest extends IntegrationFixture implements ImageFile
                 .when()
                 .get("/posts/" + 게시글_id)
                 .then()
+                .log().all()
                 .extract();
 
         final String 유지할_이미지의_url = 게시글_상세_조회_응답.body().jsonPath().getString("images[0]");
+
         final ExtractableResponse<Response> 게시글_수정_응답 = RestAssured.given()
                 .multiPart("title", "제목을 수정하자")
                 .multiPart("content", "내용을 수정하자")
@@ -530,14 +548,16 @@ public class PostIntegrationTest extends IntegrationFixture implements ImageFile
         final ExtractableResponse<Response> 게시글_생성_응답 = 게시글을_하나_만든다(작성자);
         final long 게시글_id = 응답의_location헤더에서_id를_추출한다(게시글_생성_응답);
 
+        final String sessionId = 로그인(작성자);
+
         final ExtractableResponse<Response> 게시글_수정_응답 = RestAssured.given()
                 .multiPart("title", "제목을 수정하자")
                 .multiPart("content", "내용을 수정하자")
                 .multiPart("price", 10000)
                 .multiPart("originalImages", "이상한url이지롱")
                 .multiPart("newImages", 이미지1)
+                .sessionId(sessionId)
                 .when()
-                .auth().preemptive().basic(작성자.getEmail(), 작성자.getPassword())
                 .put("/posts/" + 게시글_id)
                 .then()
                 .extract();
@@ -557,14 +577,16 @@ public class PostIntegrationTest extends IntegrationFixture implements ImageFile
         final ExtractableResponse<Response> 게시글_생성_응답 = 게시글을_하나_만든다(작성자);
         final long 게시글_id = 응답의_location헤더에서_id를_추출한다(게시글_생성_응답);
 
+        final String sessionId = 로그인(작성자);
+
         final ExtractableResponse<Response> 게시글_수정_응답 = RestAssured.given()
                 .multiPart("title", "제목을 수정하자")
                 .multiPart("content", "내용을 수정하자")
                 .multiPart("price", 10000)
                 .multiPart("originalImages", domain + "없는이미지.jpg")
                 .multiPart("newImages", 이미지1)
+                .sessionId(sessionId)
                 .when()
-                .auth().preemptive().basic(작성자.getEmail(), 작성자.getPassword())
                 .put("/posts/" + 게시글_id)
                 .then()
                 .extract();
@@ -587,6 +609,8 @@ public class PostIntegrationTest extends IntegrationFixture implements ImageFile
 
         final String 유지할_이미지의_url = 게시글_상세_조회_응답.body().jsonPath().getString("images[0]");
 
+        final String sessionId = 로그인(작성자);
+
         final ExtractableResponse<Response> 게시글_수정_응답 = RestAssured.given()
                 .multiPart("title", "제목을 수정하자")
                 .multiPart("content", "내용을 수정하자")
@@ -602,8 +626,8 @@ public class PostIntegrationTest extends IntegrationFixture implements ImageFile
                 .multiPart("newImages", 이미지1)
                 .multiPart("newImages", 이미지1)
                 .multiPart("newImages", 이미지1)
+                .sessionId(sessionId)
                 .when()
-                .auth().preemptive().basic(작성자.getEmail(), 작성자.getPassword())
                 .put("/posts/" + 게시글_id)
                 .then()
                 .extract();

--- a/backend/src/test/java/edonymyeon/backend/report/docs/ReportDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/report/docs/ReportDocsTest.java
@@ -1,5 +1,16 @@
 package edonymyeon.backend.report.docs;
 
+import static edonymyeon.backend.auth.ui.SessionConst.USER;
+import static edonymyeon.backend.report.domain.ReportType.POST;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edonymyeon.backend.image.postimage.domain.PostImageInfos;
 import edonymyeon.backend.member.domain.Member;
@@ -13,29 +24,17 @@ import edonymyeon.backend.report.domain.AbusingType;
 import edonymyeon.backend.report.domain.Report;
 import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.support.TestMemberBuilder;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.SliceImpl;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.List;
-import java.util.Optional;
-
-import static edonymyeon.backend.report.domain.ReportType.POST;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SuppressWarnings("NonAsciiCharacters")
 @RequiredArgsConstructor
@@ -81,7 +80,6 @@ public class ReportDocsTest implements ImageFileCleaner {
         final Member 글쓴이 = testMemberBuilder.builder()
                 .id(1L)
                 .email("email@email.com")
-                .password("password123!")
                 .nickname("nickname")
                 .buildWithoutSaving();
         final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 글쓴이, PostImageInfos.create(), 0, 0);
@@ -90,14 +88,13 @@ public class ReportDocsTest implements ImageFileCleaner {
         게시글_레포지토리를_모킹한다(게시글);
         신고_서비스를_모킹한다(new Report(POST, 게시글.getId(), 글쓴이, AbusingType.OBSCENITY, ""));
 
-        final ReportRequest reportRequest = new ReportRequest("POST", 게시글.getId(), AbusingType.OBSCENITY.getTypeCode(), "");
+        final ReportRequest reportRequest = new ReportRequest("POST", 게시글.getId(), AbusingType.OBSCENITY.getTypeCode(),
+                "");
 
         final var 게시글_상세_조회_요청 = post("/report")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(reportRequest))
-                .header(HttpHeaders.AUTHORIZATION, "Basic "
-                        + java.util.Base64.getEncoder()
-                        .encodeToString((글쓴이.getEmail() + ":" + 글쓴이.getPassword()).getBytes()));
+                .sessionAttr(USER.getSessionId(), 글쓴이.getId());
 
         final RestDocumentationResultHandler 문서화 = document("report-save",
                 preprocessRequest(prettyPrint())

--- a/backend/src/test/java/edonymyeon/backend/report/ui/ReportIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/report/ui/ReportIntegrationTest.java
@@ -1,5 +1,7 @@
 package edonymyeon.backend.report.ui;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import edonymyeon.backend.comment.domain.Comment;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.post.ImageFileCleaner;
@@ -12,14 +14,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @SuppressWarnings("NonAsciiCharacters")
 class ReportIntegrationTest extends IntegrationFixture implements ImageFileCleaner {
 
     @Test
     void 특정_게시글을_신고한다() {
         final Member member = 사용자를_하나_만든다();
+        final String sessionId = 로그인(member);
         final ExtractableResponse<Response> post = 게시글을_하나_만든다(member);
         final long postId = 응답의_location헤더에서_id를_추출한다(post);
 
@@ -27,10 +28,10 @@ class ReportIntegrationTest extends IntegrationFixture implements ImageFileClean
 
         final ExtractableResponse<Response> 게시글_신고_응답 = RestAssured
                 .given()
+                .sessionId(sessionId)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(reportRequest)
                 .when()
-                .auth().preemptive().basic(member.getEmail(), member.getPassword())
                 .post("/report")
                 .then()
                 .extract();
@@ -46,12 +47,14 @@ class ReportIntegrationTest extends IntegrationFixture implements ImageFileClean
 
         final ReportRequest reportRequest = new ReportRequest("COMMENT", 댓글.getId(), 4, null);
 
+        final String sessionId = 로그인(member);
+
         final ExtractableResponse<Response> 댓글_신고_응답 = RestAssured
                 .given()
+                .sessionId(sessionId)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(reportRequest)
                 .when()
-                .auth().preemptive().basic(member.getEmail(), member.getPassword())
                 .post("/report")
                 .then()
                 .extract();
@@ -91,12 +94,14 @@ class ReportIntegrationTest extends IntegrationFixture implements ImageFileClean
         // then
         final ReportRequest reportRequest = new ReportRequest(null, postId, 4, null);
 
+        final String sessionId = 로그인(member);
+
         final ExtractableResponse<Response> 게시글_신고_응답 = RestAssured
                 .given()
+                .sessionId(sessionId)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(reportRequest)
                 .when()
-                .auth().preemptive().basic(member.getEmail(), member.getPassword())
                 .post("/report")
                 .then()
                 .extract();
@@ -110,6 +115,8 @@ class ReportIntegrationTest extends IntegrationFixture implements ImageFileClean
         final Member member = 사용자를_하나_만든다();
         final ExtractableResponse<Response> post = 게시글을_하나_만든다(member);
         final long postId = 응답의_location헤더에서_id를_추출한다(post);
+
+        final String sessionId = 로그인(member);
         // when
 
         // then
@@ -117,10 +124,10 @@ class ReportIntegrationTest extends IntegrationFixture implements ImageFileClean
 
         final ExtractableResponse<Response> 게시글_신고_응답 = RestAssured
                 .given()
+                .sessionId(sessionId)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(reportRequest)
                 .when()
-                .auth().preemptive().basic(member.getEmail(), member.getPassword())
                 .post("/report")
                 .then()
                 .extract();

--- a/backend/src/test/java/edonymyeon/backend/setting/docs/SettingControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/setting/docs/SettingControllerDocsTest.java
@@ -1,8 +1,7 @@
 package edonymyeon.backend.setting.docs;
 
+import static edonymyeon.backend.auth.ui.SessionConst.USER;
 import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -27,7 +26,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.test.web.servlet.MockMvc;
@@ -55,7 +53,8 @@ public class SettingControllerDocsTest extends DocsTest {
         when(settingService.findSettingsByMemberId(new ActiveMemberId(회원.getId()))).thenReturn(new SettingsResponse(
                 List.of(
                         new SettingResponse(SettingType.NOTIFICATION.getSerialNumber(), false),
-                        new SettingResponse(SettingType.NOTIFICATION_CONSUMPTION_CONFIRMATION_REMINDING.getSerialNumber(), false),
+                        new SettingResponse(
+                                SettingType.NOTIFICATION_CONSUMPTION_CONFIRMATION_REMINDING.getSerialNumber(), false),
                         new SettingResponse(SettingType.NOTIFICATION_PER_COMMENT.getSerialNumber(), false),
                         new SettingResponse(SettingType.NOTIFICATION_PER_10_THUMBS.getSerialNumber(), false),
                         new SettingResponse(SettingType.NOTIFICATION_PER_THUMBS.getSerialNumber(), false)
@@ -64,15 +63,10 @@ public class SettingControllerDocsTest extends DocsTest {
 
         final MockHttpServletRequestBuilder 설정_조회_요청 = get("/preference/notification")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, "Basic "
-                        + java.util.Base64.getEncoder()
-                        .encodeToString((회원.getEmail() + ":" + 회원.getPassword()).getBytes()));
+                .sessionAttr(USER.getSessionId(), 회원.getId());
 
         final RestDocumentationResultHandler 문서화 = document("notification-findAll",
                 preprocessRequest(prettyPrint()),
-                requestHeaders(
-                        headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
-                ),
                 responseFields(
                         fieldWithPath("notifications").description("사용자가 수정 가능한 설정의 리스트"),
                         fieldWithPath("notifications[].preferenceType").description("설정의 고유 식별자"),
@@ -93,7 +87,8 @@ public class SettingControllerDocsTest extends DocsTest {
         when(settingService.findSettingsByMemberId(new ActiveMemberId(회원.getId()))).thenReturn(new SettingsResponse(
                 List.of(
                         new SettingResponse(SettingType.NOTIFICATION.getSerialNumber(), true),
-                        new SettingResponse(SettingType.NOTIFICATION_CONSUMPTION_CONFIRMATION_REMINDING.getSerialNumber(), false),
+                        new SettingResponse(
+                                SettingType.NOTIFICATION_CONSUMPTION_CONFIRMATION_REMINDING.getSerialNumber(), false),
                         new SettingResponse(SettingType.NOTIFICATION_PER_COMMENT.getSerialNumber(), false),
                         new SettingResponse(SettingType.NOTIFICATION_PER_10_THUMBS.getSerialNumber(), true),
                         new SettingResponse(SettingType.NOTIFICATION_PER_THUMBS.getSerialNumber(), false)
@@ -102,16 +97,12 @@ public class SettingControllerDocsTest extends DocsTest {
 
         final MockHttpServletRequestBuilder 설정_조회_요청 = post("/preference/notification")
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, "Basic "
-                        + java.util.Base64.getEncoder()
-                        .encodeToString((회원.getEmail() + ":" + 회원.getPassword()).getBytes()))
-                .content(objectMapper.writeValueAsString(new SettingRequest(SettingType.NOTIFICATION_PER_10_THUMBS.getSerialNumber())));
+                .sessionAttr(USER.getSessionId(), 회원.getId())
+                .content(objectMapper.writeValueAsString(
+                        new SettingRequest(SettingType.NOTIFICATION_PER_10_THUMBS.getSerialNumber())));
 
         final RestDocumentationResultHandler 문서화 = document("notification-toggle",
                 preprocessRequest(prettyPrint()),
-                requestHeaders(
-                        headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
-                ),
                 requestFields(
                         fieldWithPath("preferenceType").description("활성화 또는 비활성화한 설정의 고유 식별자")
                 ),

--- a/backend/src/test/java/edonymyeon/backend/setting/ui/SettingIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/setting/ui/SettingIntegrationTest.java
@@ -23,6 +23,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 class SettingIntegrationTest extends IntegrationFixture {
+
     private static void 설정값_검증(final List<Map<String, String>> settingDetails, final String 고유번호, final String 활성화여부) {
         settingDetails.stream().filter(setting -> Objects.equals(setting.get("preferenceType"), 고유번호))
                 .findAny()
@@ -39,13 +40,16 @@ class SettingIntegrationTest extends IntegrationFixture {
         final String password = "test123!";
         authService.joinMember(new JoinRequest(email, password, "nickname", "testDeviceToken"));
 
+        final String sessionId = 로그인(email, password);
+
         ExtractableResponse<Response> response = RestAssured
                 .given()
-                .auth().preemptive().basic(email, password)
+                .sessionId(sessionId)
                 .when()
                 .get("/preference/notification")
                 .then()
                 .statusCode(HttpStatus.OK.value())
+                .log().all()
                 .extract();
 
         final Map<String, List<Map<String, String>>> settings = objectMapper.readValue(response.body().asByteArray(),
@@ -62,12 +66,13 @@ class SettingIntegrationTest extends IntegrationFixture {
         final String 이메일 = "test@gmail.com";
         final String 비밀번호 = "test123!";
         authService.joinMember(new JoinRequest(이메일, 비밀번호, "nickname", "testDeviceToken"));
+        final String sessionId = 로그인(이메일, 비밀번호);
 
         final SettingType 반응_열건당_알림_설정정보 = SettingType.NOTIFICATION_PER_10_THUMBS;
         ExtractableResponse<Response> response = RestAssured
                 .given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .auth().preemptive().basic(이메일, 비밀번호)
+                .sessionId(sessionId)
                 .body(new SettingRequest(반응_열건당_알림_설정정보.getSerialNumber()))
                 .when()
                 .post("/preference/notification")

--- a/backend/src/test/java/edonymyeon/backend/support/TestMemberBuilder.java
+++ b/backend/src/test/java/edonymyeon/backend/support/TestMemberBuilder.java
@@ -1,5 +1,6 @@
 package edonymyeon.backend.support;
 
+import edonymyeon.backend.auth.domain.SimplePasswordEncoder;
 import edonymyeon.backend.image.profileimage.domain.ProfileImageInfo;
 import edonymyeon.backend.member.domain.Device;
 import edonymyeon.backend.member.domain.Member;
@@ -28,6 +29,10 @@ public class TestMemberBuilder {
 
     private final MemberRepository memberRepository;
 
+    public static String getRawPassword() {
+        return DEFAULT_PASSWORD;
+    }
+
     public MemberBuilder builder() {
         return new MemberBuilder();
     }
@@ -37,8 +42,6 @@ public class TestMemberBuilder {
         private Long id;
 
         private String email;
-
-        private String password;
 
         private String nickname;
 
@@ -57,11 +60,6 @@ public class TestMemberBuilder {
 
         public MemberBuilder email(final String email) {
             this.email = email;
-            return this;
-        }
-
-        public MemberBuilder password(final String password) {
-            this.password = password;
             return this;
         }
 
@@ -93,11 +91,13 @@ public class TestMemberBuilder {
         public Member build() {
             final Member member = new Member(
                     this.email != null ? this.email : DEFAULT_EMAIL + emailCount++,
-                    this.password != null ? this.password : DEFAULT_PASSWORD,
+                    DEFAULT_PASSWORD,
                     this.nickname != null ? this.nickname : DEFAULT_NICK_NAME + nickNameCount++,
                     this.profileImageInfo,
                     List.of()
             );
+            encryptPassword(member);
+
             setField(member, "id", this.id, null);
             setField(member, "socialInfo", this.socialInfo, null);
             setField(member, "devices", this.devices, List.of(new Device("testToken", member)));
@@ -105,10 +105,16 @@ public class TestMemberBuilder {
             return memberRepository.save(member);
         }
 
+        private void encryptPassword(final Member member) {
+            final SimplePasswordEncoder encoder = new SimplePasswordEncoder();
+            final String encodedPassword = encoder.encode(DEFAULT_PASSWORD);
+            member.encrypt(encodedPassword);
+        }
+
         public Member buildWithoutSaving() {
             final Member member = new Member(
                     this.email != null ? this.email : DEFAULT_EMAIL + emailCount++,
-                    this.password != null ? this.password : DEFAULT_PASSWORD,
+                    DEFAULT_PASSWORD,
                     this.nickname != null ? this.nickname : DEFAULT_NICK_NAME + nickNameCount++,
                     this.profileImageInfo,
                     List.of()
@@ -130,5 +136,4 @@ public class TestMemberBuilder {
             ReflectionUtils.setField(field, member, orElse);
         }
     }
-
 }

--- a/backend/src/test/java/edonymyeon/backend/thumbs/docs/ThumbsControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/thumbs/docs/ThumbsControllerDocsTest.java
@@ -1,5 +1,14 @@
 package edonymyeon.backend.thumbs.docs;
 
+import static edonymyeon.backend.auth.ui.SessionConst.USER;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.domain.Post;
@@ -9,27 +18,15 @@ import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.thumbs.domain.Thumbs;
 import edonymyeon.backend.thumbs.domain.ThumbsType;
 import edonymyeon.backend.thumbs.repository.ThumbsRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-
-import java.util.Optional;
-
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SuppressWarnings("NonAsciiCharacters")
 @RequiredArgsConstructor
@@ -86,16 +83,11 @@ public class ThumbsControllerDocsTest {
         when(thumbsRepository.save(조와요)).thenReturn(조와요);
 
         final MockHttpServletRequestBuilder 좋아요_요청 = put("/posts/{postId}/up", 글.getId())
-                .header(HttpHeaders.AUTHORIZATION, "Basic "
-                        + java.util.Base64.getEncoder()
-                        .encodeToString((반응_하는_사람.getEmail() + ":" + 반응_하는_사람.getPassword()).getBytes()));
+                .sessionAttr(USER.getSessionId(), 반응_하는_사람.getId());
 
         this.mockMvc.perform(좋아요_요청)
                 .andExpect(status().isOk())
                 .andDo(document("thumbs-up",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
-                        ),
                         pathParameters(
                                 parameterWithName("postId").description("게시글 id")
                         )
@@ -108,16 +100,11 @@ public class ThumbsControllerDocsTest {
         when(thumbsRepository.save(시러요)).thenReturn(시러요);
 
         final MockHttpServletRequestBuilder 싫어요_요청 = put("/posts/{postId}/down", 글.getId())
-                .header(HttpHeaders.AUTHORIZATION, "Basic "
-                        + java.util.Base64.getEncoder()
-                        .encodeToString((반응_하는_사람.getEmail() + ":" + 반응_하는_사람.getPassword()).getBytes()));
+                .sessionAttr(USER.getSessionId(), 반응_하는_사람.getId());
 
         this.mockMvc.perform(싫어요_요청)
                 .andExpect(status().isOk())
                 .andDo(document("thumbs-down",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
-                        ),
                         pathParameters(
                                 parameterWithName("postId").description("게시글 id")
                         )
@@ -130,16 +117,11 @@ public class ThumbsControllerDocsTest {
         when(thumbsRepository.findByPostIdAndMemberId(글.getId(), 반응_하는_사람.getId())).thenReturn(Optional.of(좋아요));
 
         final MockHttpServletRequestBuilder 좋아요_취소_요청 = delete("/posts/{postId}/up", 글.getId())
-                .header(HttpHeaders.AUTHORIZATION, "Basic "
-                        + java.util.Base64.getEncoder()
-                        .encodeToString((반응_하는_사람.getEmail() + ":" + 반응_하는_사람.getPassword()).getBytes()));
+                .sessionAttr(USER.getSessionId(), 반응_하는_사람.getId());
 
         this.mockMvc.perform(좋아요_취소_요청)
                 .andExpect(status().isOk())
                 .andDo(document("thumbs-up-delete",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
-                        ),
                         pathParameters(
                                 parameterWithName("postId").description("게시글 id")
                         )
@@ -152,16 +134,11 @@ public class ThumbsControllerDocsTest {
         when(thumbsRepository.findByPostIdAndMemberId(글.getId(), 반응_하는_사람.getId())).thenReturn(Optional.of(싫어요));
 
         final MockHttpServletRequestBuilder 싫어요_취소_요청 = delete("/posts/{postId}/down", 글.getId())
-                .header(HttpHeaders.AUTHORIZATION, "Basic "
-                        + java.util.Base64.getEncoder()
-                        .encodeToString((반응_하는_사람.getEmail() + ":" + 반응_하는_사람.getPassword()).getBytes()));
+                .sessionAttr(USER.getSessionId(), 반응_하는_사람.getId());
 
         this.mockMvc.perform(싫어요_취소_요청)
                 .andExpect(status().isOk())
                 .andDo(document("thumbs-down-delete",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("서버에서 발급한 엑세스 토큰")
-                        ),
                         pathParameters(
                                 parameterWithName("postId").description("게시글 id")
                         )

--- a/backend/src/test/java/edonymyeon/backend/thumbs/integration/ThumbsIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/thumbs/integration/ThumbsIntegrationTest.java
@@ -205,8 +205,10 @@ public class ThumbsIntegrationTest extends IntegrationFixture {
     }
 
     private ExtractableResponse<Response> requestThumbs(String upOrDown, Member member, Long postId) {
+        final String sessionId = 로그인(member);
+
         return given()
-                .auth().preemptive().basic(member.getEmail(), member.getPassword())
+                .sessionId(sessionId)
                 .when()
                 .put("posts/" + postId + "/" + upOrDown)
                 .then()
@@ -215,8 +217,10 @@ public class ThumbsIntegrationTest extends IntegrationFixture {
     }
 
     private ExtractableResponse<Response> requestDeleteThumbs(String upOrDown, Member member, Long postId) {
+        final String sessionId = 로그인(member);
+
         return given()
-                .auth().preemptive().basic(member.getEmail(), member.getPassword())
+                .sessionId(sessionId)
                 .when()
                 .delete("posts/" + postId + "/" + upOrDown)
                 .then()


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #418 

## 📝 작업 요약

- 회원 탈퇴 기능을 auth 패키지로 이동 (사진 삭제 부분만 member쪽에서 하도록)
- 이미지 삭제는 트랜잭션이 커밋 후 되도록 (+ 비동기 처리되도록)

- [ ] 회원 수정(프로필 등록) 구현 후, 시간 측정

