### PR TITLE
Fix/#423 삭제된게시글 무한로딩

### DIFF
--- a/android/app/src/main/java/com/app/edonymyeon/data/common/CustomThrowableUtils.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/data/common/CustomThrowableUtils.kt
@@ -1,0 +1,12 @@
+package com.app.edonymyeon.data.common
+
+import org.json.JSONObject
+import retrofit2.Response
+
+fun <T : Any> createCustomThrowableFromResponse(result: Response<T>): CustomThrowable {
+    val errorResponse = result.errorBody()?.string()
+    val json = errorResponse?.let { JSONObject(it) }
+    val errorMessage = json?.getString("errorMessage") ?: ""
+    val errorCode = json?.getInt("errorCode") ?: 0
+    return CustomThrowable(errorCode, errorMessage)
+}

--- a/android/app/src/main/java/com/app/edonymyeon/data/repository/AuthRepositoryImpl.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/data/repository/AuthRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.app.edonymyeon.data.repository
 
 import com.app.edonymyeon.data.common.CustomThrowable
+import com.app.edonymyeon.data.common.createCustomThrowableFromResponse
 import com.app.edonymyeon.data.datasource.auth.AuthDataSource
 import com.app.edonymyeon.data.dto.LoginDataModel
 import com.app.edonymyeon.data.dto.request.LogoutRequest
@@ -46,10 +47,8 @@ class AuthRepositoryImpl(
             authLocalDataSource.setAuthToken(result.headers()["Authorization"] as String)
             Result.success(result.body() ?: Unit)
         } else {
-            val errorResponse = result.errorBody()?.string()
-            val json = errorResponse?.let { JSONObject(it) }
-            val errorMessage = json?.getString("errorMessage") ?: ""
-            Result.failure(CustomThrowable(result.code(), errorMessage))
+            val customThrowable = createCustomThrowableFromResponse(result)
+            Result.failure(customThrowable)
         }
     }
 

--- a/android/app/src/main/java/com/app/edonymyeon/data/repository/PostRepositoryImpl.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/data/repository/PostRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.app.edonymyeon.data.repository
 
 import com.app.edonymyeon.data.common.CustomThrowable
+import com.app.edonymyeon.data.common.createCustomThrowableFromResponse
 import com.app.edonymyeon.data.datasource.post.PostDataSource
 import com.app.edonymyeon.data.dto.response.CommentsResponse
 import com.app.edonymyeon.data.dto.response.PostDetailResponse
@@ -19,7 +20,8 @@ class PostRepositoryImpl(private val postDataSource: PostDataSource) : PostRepos
         return if (result.isSuccessful) {
             Result.success((result.body() as PostDetailResponse).toDomain())
         } else {
-            Result.failure(CustomThrowable(result.code(), result.message()))
+            val customThrowable = createCustomThrowableFromResponse(result)
+            Result.failure(customThrowable)
         }
     }
 

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/post/PostActivity.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/post/PostActivity.kt
@@ -98,6 +98,11 @@ class PostActivity : AppCompatActivity() {
                 ) { navigateToLogin() }
             }
         }
+
+        binding.srlRefresh.setOnRefreshListener {
+            binding.srlRefresh.isRefreshing = false
+            loadNewData()
+        }
     }
 
     private fun loadNewData() {

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/postdetail/PostDetailActivity.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/postdetail/PostDetailActivity.kt
@@ -15,7 +15,6 @@ import android.widget.LinearLayout
 import android.widget.ScrollView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.viewpager2.widget.ViewPager2
@@ -35,6 +34,7 @@ import com.app.edonymyeon.presentation.ui.post.PostActivity
 import com.app.edonymyeon.presentation.ui.postdetail.adapter.CommentAdapter
 import com.app.edonymyeon.presentation.ui.postdetail.adapter.ImageSliderAdapter
 import com.app.edonymyeon.presentation.ui.postdetail.dialog.DeleteDialog
+import com.app.edonymyeon.presentation.ui.postdetail.dialog.PostDeletedDialog
 import com.app.edonymyeon.presentation.ui.postdetail.dialog.ReportDialog
 import com.app.edonymyeon.presentation.ui.postdetail.listener.CommentClickListener
 import com.app.edonymyeon.presentation.ui.posteditor.PostEditorActivity
@@ -81,6 +81,12 @@ class PostDetailActivity : AppCompatActivity(), CommentClickListener {
 
     private val loadingDialog: LoadingDialog by lazy {
         LoadingDialog(getString(R.string.post_detail_loading))
+    }
+
+    private val postDeletedDialog: PostDeletedDialog by lazy {
+        PostDeletedDialog {
+            finish()
+        }
     }
 
     private val adapter: CommentAdapter by lazy {
@@ -253,7 +259,7 @@ class PostDetailActivity : AppCompatActivity(), CommentClickListener {
 
         viewModel.isPostDeleted.observe(this) {
             if (it) {
-                createPostDeletedDialog()
+                postDeletedDialog.show(supportFragmentManager, "PostDeletedDialog")
             }
         }
     }
@@ -397,14 +403,6 @@ class PostDetailActivity : AppCompatActivity(), CommentClickListener {
         } else {
             makeLoginSnackbar()
         }
-    }
-
-    private fun createPostDeletedDialog() {
-        AlertDialog.Builder(this)
-            .setMessage("삭제된 게시글입니다.")
-            .setPositiveButton(
-                "확인",
-            ) { _, _ -> finish() }.create().show()
     }
 
     companion object {

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/postdetail/PostDetailActivity.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/postdetail/PostDetailActivity.kt
@@ -15,6 +15,7 @@ import android.widget.LinearLayout
 import android.widget.ScrollView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.viewpager2.widget.ViewPager2
@@ -249,6 +250,12 @@ class PostDetailActivity : AppCompatActivity(), CommentClickListener {
         viewModel.reportSaveMessage.observe(this) {
             binding.root.makeSnackbar(it)
         }
+
+        viewModel.isPostDeleted.observe(this) {
+            if (it) {
+                createPostDeletedDialog()
+            }
+        }
     }
 
     private fun setListener() {
@@ -390,6 +397,14 @@ class PostDetailActivity : AppCompatActivity(), CommentClickListener {
         } else {
             makeLoginSnackbar()
         }
+    }
+
+    private fun createPostDeletedDialog() {
+        AlertDialog.Builder(this)
+            .setMessage("삭제된 게시글입니다.")
+            .setPositiveButton(
+                "확인",
+            ) { _, _ -> finish() }.create().show()
     }
 
     companion object {

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/postdetail/PostDetailViewModel.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/postdetail/PostDetailViewModel.kt
@@ -78,6 +78,10 @@ class PostDetailViewModel(
     val reportSaveMessage: LiveData<String>
         get() = _reportSaveMessage
 
+    private val _isPostDeleted = MutableLiveData(false)
+    val isPostDeleted: LiveData<Boolean>
+        get() = _isPostDeleted
+
     fun getPostDetail(postId: Long) {
         viewModelScope.launch {
             postRepository.getPostDetail(postId)
@@ -89,8 +93,15 @@ class PostDetailViewModel(
                     _isPostLoadingSuccess.value = true
                     checkLoadingSuccess()
                 }.onFailure {
-                    it as CustomThrowable
-                    _isPostLoadingSuccess.value = false
+                    val customThrowable = it as CustomThrowable
+                    when (customThrowable.code) {
+                        2000 -> {
+                            _isPostDeleted.value = true
+                            _isLoadingSuccess.value = true
+                        }
+
+                        else -> _isPostLoadingSuccess.value = false
+                    }
                 }
         }
     }

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/postdetail/dialog/PostDeletedDialog.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/postdetail/dialog/PostDeletedDialog.kt
@@ -1,0 +1,39 @@
+package com.app.edonymyeon.presentation.ui.postdetail.dialog
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentManager
+import app.edonymyeon.databinding.DialogPostDeletedBinding
+
+class PostDeletedDialog(
+    private val onPositiveButtonClick: () -> Unit,
+) : DialogFragment() {
+
+    private lateinit var binding: DialogPostDeletedBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        binding = DialogPostDeletedBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+
+        binding.tvDialogOk.setOnClickListener { onPositiveButtonClick() }
+    }
+
+    override fun show(manager: FragmentManager, tag: String?) {
+        super.show(manager, tag)
+        isCancelable = false
+    }
+}

--- a/android/app/src/main/res/layout/activity_post.xml
+++ b/android/app/src/main/res/layout/activity_post.xml
@@ -31,32 +31,42 @@
             android:id="@+id/space_recyclerview_top"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            app:layout_constraintDimensionRatio="h,360:44"
+            app:layout_constraintDimensionRatio="h,360:16"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tb_post" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rv_post"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/srl_refresh"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/space_recyclerview_top" />
+            app:layout_constraintTop_toBottomOf="@id/space_recyclerview_top">
 
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/fab_post_new"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="24dp"
-            android:layout_marginBottom="84dp"
-            android:src="@drawable/ic_write_post"
-            app:backgroundTint="@color/blue_576b9e"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:tint="@color/white_ffffff" />
 
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_post"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/space_recyclerview_top" />
+
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/fab_post_new"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="24dp"
+                android:layout_marginBottom="84dp"
+                android:src="@drawable/ic_write_post"
+                app:backgroundTint="@color/blue_576b9e"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:tint="@color/white_ffffff" />
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout/activity_post.xml
+++ b/android/app/src/main/res/layout/activity_post.xml
@@ -56,17 +56,18 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/space_recyclerview_top" />
 
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/fab_post_new"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="24dp"
-                android:layout_marginBottom="84dp"
-                android:src="@drawable/ic_write_post"
-                app:backgroundTint="@color/blue_576b9e"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:tint="@color/white_ffffff" />
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab_post_new"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="24dp"
+            android:layout_marginBottom="84dp"
+            android:src="@drawable/ic_write_post"
+            app:backgroundTint="@color/blue_576b9e"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:tint="@color/white_ffffff" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout/activity_post_detail.xml
+++ b/android/app/src/main/res/layout/activity_post_detail.xml
@@ -110,12 +110,13 @@
 
                     <TextView
                         android:id="@+id/tv_title"
-                        android:layout_width="wrap_content"
-                        android:layout_height="0dp"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
                         android:text="@{postViewModel.post.title}"
                         android:textColor="@color/black_434343"
                         android:textSize="20sp"
                         android:textStyle="bold"
+                        app:layout_constraintEnd_toStartOf="@+id/space_content_end"
                         app:layout_constraintStart_toEndOf="@id/space_content_start"
                         app:layout_constraintTop_toBottomOf="@id/space_image_bottom"
                         tools:text="립스틱 살까말까 고민 중인데..." />

--- a/android/app/src/main/res/layout/dialog_post_deleted.xml
+++ b/android/app/src/main/res/layout/dialog_post_deleted.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_ffffff_radius_15">
+
+        <Space
+            android:id="@+id/space_title_top"
+            android:layout_width="252dp"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="H, 252:40"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_dialog_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/post_detail_deleted_dialog_title"
+            android:textColor="@color/black_434343"
+            android:textSize="18sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/space_title_top" />
+
+        <Space
+            android:id="@+id/space_title_bottom"
+            android:layout_width="250dp"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="H, 252:28"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_dialog_title" />
+
+        <TextView
+            android:id="@+id/tv_dialog_ok"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="32dp"
+            android:text="@string/post_detail_deleted_dialog_yes"
+            android:textColor="@color/blue_576b9e"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/space_title_bottom" />
+
+        <Space
+            android:id="@+id/space_ok_bottom"
+            android:layout_width="250dp"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="H, 252:32"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_dialog_ok" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/item_comment.xml
+++ b/android/app/src/main/res/layout/item_comment.xml
@@ -60,7 +60,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="20dp"
-            android:text="@{comment.nicknameUiModel.nickname}"
+            android:text="@{comment.nicknameUiModel.toString()}"
             android:textColor="@color/gray_666666"
             android:textSize="13sp"
             app:layout_constraintStart_toStartOf="parent"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -48,6 +48,8 @@
     <string name="post_detail_dialog_yes">예</string>
     <string name="post_detail_dialog_no">아니요</string>
     <string name="post_detail_loading">로딩 중입니다</string>
+    <string name="post_detail_deleted_dialog_title">삭제된 게시글입니다</string>
+    <string name="post_detail_deleted_dialog_yes">확인</string>
 
     <!--post report dialog -->
     <string name="post_report_dialog_title">신고 사유</string>


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #423 

## 📝 작업 요약

삭제된 게시글을 클릭시 무한로딩 되지 않도록 수정하였습니다.

## 🔎 작업 상세 설명

삭제된 게시글 클릭 시 무한로딩 되지 않고 '삭제된 게시글입니다.'라고 Dialog 뜰 수 있도록 하였습니다.
수정하는 김에 에러 코드에 대한 처리 하는 부분을 공통함수로 빼서 서버에서 전달하는 에러코드와 메시지를 CustomThrowable로 관리할 수 있도록 하였습니다!!
전체 게시물 refreshlayout 적용했고 게시글 상세에 제목 길이가 길어지는 경우에 잘리는 문제를 수정하였습니다. 

## 🌟 리뷰 요구 사항

PostDetail에 상태가 점점 많아지면서 UiState로 리팩토링의 필요성을 느끼게 되네요😂 
