### PR TITLE
Fix/#376 배포 이전 버전의 restdocs 문서가 조회되는 이슈 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,127 +1,110 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.1.1'
-	id 'io.spring.dependency-management' version '1.1.0'
-	id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    id 'java'
+    id 'org.springframework.boot' version '3.1.1'
+    id 'io.spring.dependency-management' version '1.1.0'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = '2023-edonymyeon'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	asciidoctorExtensions
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    asciidoctorExtensions
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext {
-	set('snippetsDir', file("build/generated-snippets"))
+    set('snippetsDir', file("build/generated-snippets"))
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'net.logstash.logback:logstash-logback-encoder:6.1'
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'net.logstash.logback:logstash-logback-encoder:6.1'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
-	testImplementation 'junit:junit:4.13.1'
-	runtimeOnly 'com.h2database:h2'
+    testImplementation 'junit:junit:4.13.1'
+    runtimeOnly 'com.h2database:h2'
 
     compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testCompileOnly 'org.projectlombok:lombok'
-	testAnnotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
-	// FCM 알림 전송
-	implementation 'com.google.firebase:firebase-admin:9.2.0'
-	implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+    // FCM 알림 전송
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
 
-	// sql 파라미터 보여준 애 나중에 지워잉
-	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+    // sql 파라미터 보여준 애 나중에 지워잉
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 
-	// rest assured 추가
-	testImplementation 'io.rest-assured:rest-assured:5.3.1'
+    // rest assured 추가
+    testImplementation 'io.rest-assured:rest-assured:5.3.1'
 
-	// 스케줄러 테스트 의존성
-	testImplementation 'org.awaitility:awaitility:4.2.0'
+    // 스케줄러 테스트 의존성
+    testImplementation 'org.awaitility:awaitility:4.2.0'
 
-	implementation 'com.mysql:mysql-connector-j'
+    implementation 'com.mysql:mysql-connector-j'
 
-	// actuator 추가
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	// 프로메테우스 추가
-	implementation 'io.micrometer:micrometer-registry-prometheus'
+    // actuator 추가
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    // 프로메테우스 추가
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
-	// build/generated-snippets 에 생긴 .adoc 조각들을 프로젝트 내의 .adoc 파일에서 읽어들일 수 있도록 연동해줍니다.
-	// 이 덕분에 .adoc 파일에서 operation 같은 매크로를 사용하여 스니펫 조각들을 연동할 수 있는 것입니다.
-	// 그리고 최종적으로 .adoc 파일을 HTML로 만들어 export 해줍니다.
-	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    // build/generated-snippets 에 생긴 .adoc 조각들을 프로젝트 내의 .adoc 파일에서 읽어들일 수 있도록 연동해줍니다.
+    // 이 덕분에 .adoc 파일에서 operation 같은 매크로를 사용하여 스니펫 조각들을 연동할 수 있는 것입니다.
+    // 그리고 최종적으로 .adoc 파일을 HTML로 만들어 export 해줍니다.
+    asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
-	// redis
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-	// flyway 추가
-	implementation 'org.flywaydb:flyway-mysql'
-	implementation 'org.flywaydb:flyway-core'
+    // flyway 추가
+    implementation 'org.flywaydb:flyway-mysql'
+    implementation 'org.flywaydb:flyway-core'
 }
 
 tasks.named('test') {
-	outputs.dir snippetsDir
-	useJUnitPlatform()
+    outputs.dir snippetsDir
+    useJUnitPlatform()
 }
 
-tasks.named('asciidoctor') {
-	inputs.dir snippetsDir
-	dependsOn test
+asciidoctor {
+    dependsOn test // test 작업 이후에 작동하도록 하는 설정
+    configurations 'asciidoctorExtensions' // 위에서 작성한 configuration 적용
+    inputs.dir snippetsDir // snippetsDir 를 입력으로 구성
+
+    // source가 없으면 .adoc파일을 전부 html로 만들어버림
+    // source 지정시 특정 adoc만 HTML로 만든다.
+    sources {
+        include("**/index.adoc", "**/common/*.adoc")
+    }
+
+    // 특정 .adoc에 다른 adoc 파일을 가져와서(include) 사용하고 싶을 경우 경로를 baseDir로 맞춰주는 설정입니다.
+    // 개별 adoc으로 운영한다면 필요 없는 옵션입니다.
+    baseDirFollowsSourceFile()
 }
 
-test {
-	// 위에서 작성한 snippetsDir 디렉토리를 test의 output으로 구성하는 설정 -> 스니펫 조각들이 build/generated-snippets로 출력
-	outputs.dir snippetsDir
-	useJUnitPlatform()
-}
-
-asciidoctor { // asciidoctor 작업 구성
-	dependsOn test // test 작업 이후에 작동하도록 하는 설정
-	configurations 'asciidoctorExtensions' // 위에서 작성한 configuration 적용
-	inputs.dir snippetsDir // snippetsDir 를 입력으로 구성
-
-	// source가 없으면 .adoc파일을 전부 html로 만들어버림
-	// source 지정시 특정 adoc만 HTML로 만든다.
-	sources {
-		include("**/index.adoc", "**/common/*.adoc")
-	}
-
-	// 특정 .adoc에 다른 adoc 파일을 가져와서(include) 사용하고 싶을 경우 경로를 baseDir로 맞춰주는 설정입니다.
-	// 개별 adoc으로 운영한다면 필요 없는 옵션입니다.
-	baseDirFollowsSourceFile()
-}
-
-// static/docs 폴더 비우기
-asciidoctor.doFirst {
-	delete file('src/main/resources/static/docs')
-}
-
-// asccidoctor 작업 이후 생성된 HTML 파일을 static/docs 로 copy
 tasks.register('copyDocument', Copy) {
-	dependsOn asciidoctor
-	from file("build/docs/asciidoc")
-	into file("src/main/resources/static/docs")
+    dependsOn asciidoctor
+    from("${asciidoctor.outputDir}/html5") {
+        into 'static/docs'
+    }
 }
 
-// build 의 의존작업 명시
-build {
-	dependsOn copyDocument
+bootJar {
+    dependsOn copyDocument
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,110 +1,110 @@
 plugins {
-    id 'java'
-    id 'org.springframework.boot' version '3.1.1'
-    id 'io.spring.dependency-management' version '1.1.0'
-    id 'org.asciidoctor.jvm.convert' version '3.3.2'
+	id 'java'
+	id 'org.springframework.boot' version '3.1.1'
+	id 'io.spring.dependency-management' version '1.1.0'
+	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = '2023-edonymyeon'
 version = '0.0.1-SNAPSHOT'
 
 java {
-    sourceCompatibility = '17'
+	sourceCompatibility = '17'
 }
 
 configurations {
-    asciidoctorExtensions
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
+	asciidoctorExtensions
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
 }
 
 repositories {
-    mavenCentral()
+	mavenCentral()
 }
 
 ext {
-    set('snippetsDir', file("build/generated-snippets"))
+	set('snippetsDir', file("build/generated-snippets"))
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'net.logstash.logback:logstash-logback-encoder:6.1'
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'net.logstash.logback:logstash-logback-encoder:6.1'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
-    testImplementation 'junit:junit:4.13.1'
-    runtimeOnly 'com.h2database:h2'
+	testImplementation 'junit:junit:4.13.1'
+	runtimeOnly 'com.h2database:h2'
 
     compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
-    testCompileOnly 'org.projectlombok:lombok'
-    testAnnotationProcessor 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
-    // FCM 알림 전송
-    implementation 'com.google.firebase:firebase-admin:9.2.0'
-    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+	// FCM 알림 전송
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
+	implementation 'com.squareup.okhttp3:okhttp:4.10.0'
 
-    // sql 파라미터 보여준 애 나중에 지워잉
-    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+	// sql 파라미터 보여준 애 나중에 지워잉
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 
-    // rest assured 추가
-    testImplementation 'io.rest-assured:rest-assured:5.3.1'
+	// rest assured 추가
+	testImplementation 'io.rest-assured:rest-assured:5.3.1'
 
-    // 스케줄러 테스트 의존성
-    testImplementation 'org.awaitility:awaitility:4.2.0'
+	// 스케줄러 테스트 의존성
+	testImplementation 'org.awaitility:awaitility:4.2.0'
 
-    implementation 'com.mysql:mysql-connector-j'
+	implementation 'com.mysql:mysql-connector-j'
 
-    // actuator 추가
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    // 프로메테우스 추가
-    implementation 'io.micrometer:micrometer-registry-prometheus'
+	// actuator 추가
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	// 프로메테우스 추가
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 
-    // build/generated-snippets 에 생긴 .adoc 조각들을 프로젝트 내의 .adoc 파일에서 읽어들일 수 있도록 연동해줍니다.
-    // 이 덕분에 .adoc 파일에서 operation 같은 매크로를 사용하여 스니펫 조각들을 연동할 수 있는 것입니다.
-    // 그리고 최종적으로 .adoc 파일을 HTML로 만들어 export 해줍니다.
-    asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+	// build/generated-snippets 에 생긴 .adoc 조각들을 프로젝트 내의 .adoc 파일에서 읽어들일 수 있도록 연동해줍니다.
+	// 이 덕분에 .adoc 파일에서 operation 같은 매크로를 사용하여 스니펫 조각들을 연동할 수 있는 것입니다.
+	// 그리고 최종적으로 .adoc 파일을 HTML로 만들어 export 해줍니다.
+	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
-    // redis
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-    // flyway 추가
-    implementation 'org.flywaydb:flyway-mysql'
-    implementation 'org.flywaydb:flyway-core'
+	// flyway 추가
+	implementation 'org.flywaydb:flyway-mysql'
+	implementation 'org.flywaydb:flyway-core'
 }
 
 tasks.named('test') {
-    outputs.dir snippetsDir
-    useJUnitPlatform()
+	outputs.dir snippetsDir
+	useJUnitPlatform()
 }
 
 asciidoctor {
-    dependsOn test // test 작업 이후에 작동하도록 하는 설정
-    configurations 'asciidoctorExtensions' // 위에서 작성한 configuration 적용
-    inputs.dir snippetsDir // snippetsDir 를 입력으로 구성
+	dependsOn test // test 작업 이후에 작동하도록 하는 설정
+	configurations 'asciidoctorExtensions' // 위에서 작성한 configuration 적용
+	inputs.dir snippetsDir // snippetsDir 를 입력으로 구성
 
-    // source가 없으면 .adoc파일을 전부 html로 만들어버림
-    // source 지정시 특정 adoc만 HTML로 만든다.
-    sources {
-        include("**/index.adoc", "**/common/*.adoc")
-    }
+	// source가 없으면 .adoc파일을 전부 html로 만들어버림
+	// source 지정시 특정 adoc만 HTML로 만든다.
+	sources {
+		include("**/index.adoc", "**/common/*.adoc")
+	}
 
-    // 특정 .adoc에 다른 adoc 파일을 가져와서(include) 사용하고 싶을 경우 경로를 baseDir로 맞춰주는 설정입니다.
-    // 개별 adoc으로 운영한다면 필요 없는 옵션입니다.
-    baseDirFollowsSourceFile()
+	// 특정 .adoc에 다른 adoc 파일을 가져와서(include) 사용하고 싶을 경우 경로를 baseDir로 맞춰주는 설정입니다.
+	// 개별 adoc으로 운영한다면 필요 없는 옵션입니다.
+	baseDirFollowsSourceFile()
 }
 
 tasks.register('copyDocument', Copy) {
-    dependsOn asciidoctor
-    from("${asciidoctor.outputDir}/html5") {
-        into 'static/docs'
-    }
+	dependsOn asciidoctor
+	from ("${asciidoctor.outputDir}/html5") {
+		into 'static/docs'
+	}
 }
 
 bootJar {
-    dependsOn copyDocument
+	dependsOn copyDocument
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -100,11 +100,18 @@ asciidoctor {
 
 tasks.register('copyDocument', Copy) {
 	dependsOn asciidoctor
-	from ("${asciidoctor.outputDir}/html5") {
-		into 'static/docs'
-	}
+	from asciidoctor.outputDir
+	into 'build/resources/main/static/docs'
+}
+
+jar {
+	dependsOn copyDocument
 }
 
 bootJar {
+	dependsOn copyDocument
+}
+
+resolveMainClassName {
 	dependsOn copyDocument
 }

--- a/backend/src/docs/asciidoc/common/report-api.adoc
+++ b/backend/src/docs/asciidoc/common/report-api.adoc
@@ -1,4 +1,4 @@
-[[authentication-api]]
+[[report-api]]
 == 신고
 
 === 신고 등록

--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -1,4 +1,4 @@
-= 이돈이면 API 명세서 (새로운 버전이 잘 바영되는지 테스트!!)
+= 이돈이면 API 명세서
 :toc: left
 :toclevels: 2
 :doctype: book

--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -1,4 +1,4 @@
-= 이돈이면 API 명세서
+= 이돈이면 API 명세서 (새로운 버전이 잘 바영되는지 테스트!!)
 :toc: left
 :toclevels: 2
 :doctype: book


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #376 

## 📝 작업 요약
테스트 실행 후 생기는 문서를 복사하는 작업(copyDocument)의 순서와 복제 위치(build 폴더 안)가 변경되었습니다~
build.gralde이 수정된 작업이라 한번씩 확인해주세욥~

로컬에서 ./gradlew clean build 실행하시고
build/libs 디렉토리의 jar 파일을 실행해보셔도 좋아요~

아래는 젠킨스를 통해 빌드할때 콘솔에 출력된 내용임니당

### 수정 전(젠킨스 ~59번빌드에서 확인 가능)
boot jar, jar -> test -> copyDocument -> build
<img width="559" alt="image" src="https://github.com/woowacourse-teams/2023-edonymyeon/assets/62106852/d3dac40d-0048-40d9-bfa6-7671dc0bfe9c">
<img width="331" alt="image" src="https://github.com/woowacourse-teams/2023-edonymyeon/assets/62106852/d9e1c655-3f83-4890-aff1-a37e45905d1b">



### 수정 후(젠킨스 61, 62번 빌드에서 확인 가능)
test -> copyDocument -> boot jar, jar, build
<img width="313" alt="image" src="https://github.com/woowacourse-teams/2023-edonymyeon/assets/62106852/f0c70ea9-5ca1-4696-bdc8-b02b257c8a62">

