### PR TITLE
fix: 소셜로 회원가입 시에도 설정 초기화 작업을 수행하도록 변경

### DIFF
--- a/backend/src/test/java/edonymyeon/backend/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/auth/application/AuthServiceTest.java
@@ -23,6 +23,7 @@ import edonymyeon.backend.member.application.MemberService;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.domain.SocialInfo;
+import edonymyeon.backend.member.domain.SocialInfo.SocialType;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.setting.application.SettingService;
 import edonymyeon.backend.support.IntegrationTest;
@@ -88,6 +89,14 @@ class AuthServiceTest {
     }
 
     @Test
+    void 소셜_회원가입_이후_설정초기화_작업을_수행한다() {
+        doNothing().when(settingService).initializeSettings(any());
+
+        authService.joinSocialMember(SocialInfo.of(SocialType.KAKAO, 1L), "testDeviceToken");
+        verify(settingService, atLeastOnce()).initializeSettings(any());
+    }
+
+    @Test
     void 로그인_이후_디바이스_교체_작업을_수행한다() {
         doNothing().when(memberService).activateDevice(any(), any());
 
@@ -121,7 +130,7 @@ class AuthServiceTest {
     @Test
     void 카카오_회원가입시_DB에_암호화된_비밀번호가_저장된다() {
         final SocialInfo socialInfo = SocialInfo.of(SocialInfo.SocialType.KAKAO, 1L);
-        authService.joinSocialMember(socialInfo);
+        authService.joinSocialMember(socialInfo, "testDevice");
 
         verify(passwordEncoder, atLeastOnce()).encode(any());
     }


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #459 

## 📝 작업 요약

제곧내입니다.

## 🌟 리뷰 요구 사항

일반 로그인과 소셜 로그인 매서드가 따로인 것이 개인적으로 맘에 안 듭니다 🥹
통일할 수 있으면 좋겠습니다
