### PR TITLE
#470 회원가입 쿼리 개선

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
+++ b/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
@@ -164,13 +164,13 @@ public class AuthService {
     }
 
     private void validateDuplicateEmail(final String email) {
-        if (memberRepository.findByEmail(email).isPresent()) {
+        if (memberRepository.existsByEmail(email)) {
             throw new EdonymyeonException(MEMBER_EMAIL_DUPLICATE);
         }
     }
 
     private void validateDuplicateNickname(final String nickname) {
-        if (memberRepository.findByNickname(nickname).isPresent()) {
+        if (memberRepository.existsByNickname(nickname)) {
             throw new EdonymyeonException(MEMBER_NICKNAME_INVALID);
         }
     }

--- a/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
+++ b/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
@@ -158,8 +158,9 @@ public class AuthService {
         validateDuplicateEmail(joinRequest.email());
         validateDuplicateNickname(joinRequest.nickname());
 
-        publisher.publishEvent(new JoinMemberEvent(member, joinRequest.deviceToken()));
-        return saveMember(member);
+        final Member savedMember = saveMember(member);
+        publisher.publishEvent(new JoinMemberEvent(savedMember, joinRequest.deviceToken()));
+        return savedMember;
     }
 
     private void validateDuplicateEmail(final String email) {

--- a/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
+++ b/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
@@ -25,7 +25,6 @@ import edonymyeon.backend.member.domain.SocialInfo;
 import edonymyeon.backend.member.domain.SocialInfo.SocialType;
 import edonymyeon.backend.member.repository.MemberRepository;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -87,18 +86,22 @@ public class AuthService {
      */
     public DuplicateCheckResponse checkDuplicate(final String target, final String value) {
         final ValidateType validateType = ValidateType.from(target);
-
-        if (findMemberByValidateType(validateType, value).isEmpty()) {
-            return new DuplicateCheckResponse(true);
-        }
-        return new DuplicateCheckResponse(false);
+        return new DuplicateCheckResponse(isUniqueValue(validateType, value));
     }
 
-    private Optional<Member> findMemberByValidateType(final ValidateType validateType, final String value) {
-        if (validateType.equals(ValidateType.EMAIL)) {
-            return memberRepository.findByEmail(value);
+    private boolean isUniqueValue(final ValidateType validateType, final String value) {
+        try {
+            if (validateType.equals(ValidateType.EMAIL)) {
+                validateDuplicateEmail(value);
+            }
+            if (validateType.equals(ValidateType.NICKNAME)) {
+                validateDuplicateNickname(value);
+            }
+        } catch (EdonymyeonException e) {
+            return false;
         }
-        return memberRepository.findByNickname(value);
+
+        return true;
     }
 
     /**

--- a/backend/src/main/java/edonymyeon/backend/member/application/DeviceRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/member/application/DeviceRepository.java
@@ -3,6 +3,7 @@ package edonymyeon.backend.member.application;
 import edonymyeon.backend.member.domain.Device;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Repository;
 public interface DeviceRepository extends JpaRepository<Device, Long> {
     Optional<Device> findByDeviceToken(String deviceToken);
 
+    @EntityGraph(attributePaths = "member")
     List<Device> findAllByDeviceToken(String deviceToken);
 
     Optional<Device> findByDeviceTokenAndIsActiveIsTrue(String deviceToken);

--- a/backend/src/main/java/edonymyeon/backend/member/repository/MemberRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/member/repository/MemberRepository.java
@@ -12,4 +12,8 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberCus
     Optional<Member> findByNickname(final String nickname);
 
     Optional<Member> findBySocialInfo(final SocialInfo socialInfo);
+
+    boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
 }

--- a/backend/src/main/java/edonymyeon/backend/member/repository/MemberRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/member/repository/MemberRepository.java
@@ -9,8 +9,6 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberCus
 
     Optional<Member> findByEmail(final String email);
 
-    Optional<Member> findByNickname(final String nickname);
-
     Optional<Member> findBySocialInfo(final SocialInfo socialInfo);
 
     boolean existsByEmail(String email);

--- a/backend/src/main/java/edonymyeon/backend/setting/application/SettingService.java
+++ b/backend/src/main/java/edonymyeon/backend/setting/application/SettingService.java
@@ -43,7 +43,7 @@ public class SettingService {
 
     public void initializeSettings(final Member member) {
         final List<Setting> defaultSettings = getDefaultSettings(member);
-        settingRepository.saveAll(defaultSettings);
+        settingRepository.batchSave(defaultSettings);
     }
 
     public void toggleSetting(final String settingSerialNumber, final MemberId memberId) {

--- a/backend/src/main/java/edonymyeon/backend/setting/domain/Setting.java
+++ b/backend/src/main/java/edonymyeon/backend/setting/domain/Setting.java
@@ -1,7 +1,6 @@
 package edonymyeon.backend.setting.domain;
 
 import edonymyeon.backend.member.domain.Member;
-import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -45,6 +44,14 @@ public class Setting {
 
     public void deactivate() {
         this.isActive = false;
+    }
+
+    public String findSettingName() {
+        return this.settingType.name();
+    }
+
+    public Long findMemberId() {
+        return this.member.getId();
     }
 
     public boolean isSameCategoryWith(final Setting setting) {

--- a/backend/src/main/java/edonymyeon/backend/setting/repository/SettingCustomRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/setting/repository/SettingCustomRepository.java
@@ -1,0 +1,9 @@
+package edonymyeon.backend.setting.repository;
+
+import edonymyeon.backend.setting.domain.Setting;
+import java.util.List;
+
+public interface SettingCustomRepository {
+
+    void batchSave(List<Setting> settings);
+}

--- a/backend/src/main/java/edonymyeon/backend/setting/repository/SettingRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/setting/repository/SettingRepository.java
@@ -7,7 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface SettingRepository extends JpaRepository<Setting, Long> {
+public interface SettingRepository extends JpaRepository<Setting, Long>, SettingCustomRepository {
+
     List<Setting> findByMemberId(Long memberId);
 
     Setting findByMemberIdAndSettingType(Long memberId, SettingType settingType);

--- a/backend/src/main/java/edonymyeon/backend/setting/repository/SettingRepositoryImpl.java
+++ b/backend/src/main/java/edonymyeon/backend/setting/repository/SettingRepositoryImpl.java
@@ -1,0 +1,37 @@
+package edonymyeon.backend.setting.repository;
+
+import edonymyeon.backend.setting.domain.Setting;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@RequiredArgsConstructor
+public class SettingRepositoryImpl implements SettingCustomRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    /**
+     * 다수의 Setting을 하나의 insert 쿼리로 저장해주는 메서드입니다.
+     * @param settings 저장할 Settings들입니다
+     */
+    @Override
+    public void batchSave(final List<Setting> settings) {
+        jdbcTemplate.batchUpdate("INSERT INTO setting (is_active, member_id, setting_type) values (?, ?, ?)",
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(final PreparedStatement ps, final int i) throws SQLException {
+                        ps.setBoolean(1, settings.get(i).isActive());
+                        ps.setLong(2, settings.get(i).findMemberId());
+                        ps.setString(3, settings.get(i).findSettingName());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return settings.size();
+                    }
+                });
+    }
+}

--- a/backend/src/main/resources/application-prod-test.properties
+++ b/backend/src/main/resources/application-prod-test.properties
@@ -1,4 +1,4 @@
-#MYSQL_ADDRESS=jdbc:mysql://localhost:3306/edonymyeon
+#MYSQL_ADDRESS=jdbc:mysql://localhost:3306/edonymyeon?rewriteBatchedStatements=true
 #MYSQL_USERNAME=
 #MYSQL_PASSWORD=
 #MYSQL_FLYWAY_USERNAME=

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -1,26 +1,45 @@
+# MYSQL
 spring.datasource.url=${MYSQL_ADDRESS}
 spring.datasource.username=${MYSQL_USERNAME}
 spring.datasource.password=${MYSQL_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.database=mysql
-spring.jpa.hibernate.ddl-auto=validate
+
+# ????
 file.dir=/home/ubuntu/2023-edonymyeon/resources/
 file.firebaseTokenDir=/home/ubuntu/2023-edonymyeon/resources/edonymyeon-firebase.json
 domain=${IMAGE_DOMAIN}
+
+# MULTIPART
 spring.servlet.multipart.max-file-size=20MB
 spring.servlet.multipart.max-request-size=200MB
+
+# JPA
+spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.open-in-view=false
 spring.jpa.defer-datasource-initialization=false
+
+# ?????
 spring.sql.init.data-locations=classpath:data.sql
 spring.sql.init.mode=never
+
+# PROMETHEUS
 management.endpoints.web.exposure.include=prometheus
 management.endpoint.prometheus.enabled=true
 server.tomcat.mbeanregistry.enabled=true
+
+# FLYWAY
 spring.flyway.enabled=true
 spring.flyway.url=${MYSQL_ADDRESS}
 spring.flyway.user=${MYSQL_FLYWAY_USERNAME}
 spring.flyway.password=${MYSQL_FLYWAY_PASSWORD}
 spring.flyway.baseline-on-migrate=true
 spring.flyway.locations=classpath:db/migration/mysql
+
+# REDIS
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
+
+# SQL ??
+logging.level.org.springframework.jdbc.core=DEBUG
+logging.level.org.hibernate.SQL=DEBUG

--- a/backend/src/main/resources/db/migration/mysql/V1.3.4__add_device_token_index.sql
+++ b/backend/src/main/resources/db/migration/mysql/V1.3.4__add_device_token_index.sql
@@ -1,0 +1,1 @@
+create index i_device_device_token on device(device_token);


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #470 

## 📝 작업 요약

호이가 작성해준 [회원가입 API 쿼리 정리 문서](https://www.notion.so/e33495efa9c74a5cbcb6b1dfe9259ca3?pvs=4)에서 보이는 성능 병목점을 완화했습니다.
(회원가입 1,500건 기준 156.27초 -> 33.47초)

+ 인덱스 적용 후 더 빨라졌습니다! (위와 다른 조건의 20,000건 기준 158초 ->  31.5초)

## 🔎 작업 상세 설명

# 문제 파악

기존 쿼리에서 보이는 문제점은 크게 3가지였습니다.
1. Member 저장보다 Setting 저장을 먼저 한다.
그래서 Setting을 저장할 때 member_id를 null로 저장한 후,
Member가 저장되고 나면 Setting의 member_id 값을 변경하는 update 쿼리를 추가로 보낸다.
```SQL
insert into 
	setting (is_active,member_id,setting_type) 
values 
	(false,NULL,'NOTIFICATION_PER_COMMENT');
```
-> 
회원 저장
->
```SQL
update 
	setting 
set 
	is_active=false,member_id=2,setting_type='NOTIFICATION_PER_COMMENT' 
where 
	id=8;
```

2. 회원 한 사람이 활성화/비활성화할 수 있는 Setting 항목이 N개라고 할 때,
회원 하나를 저장한 후 회원에 대한 각 Setting을 저장하는 쿼리가 N개 나간다. (N+1 INSERT)

3. Setting과 연관관계를 가지고 있는 Member의 정보를 이용하는 과정에서 발생하는 N+1 문제 (N+1 SELECT)

4. 닉네임/이메일 중복 확인은 컬럼의 존재 여부만 확인하면 되는데, 
select *를 호출하여 사용하지 않는 데이터를 모두 가져오는 비효율 문제

---

# 해결

1. 1번의 문제를 해결하기 위해 batchInsert를 사용했습니다. 저는 batchInsert를 사용하는 방법으로 JPA를 활용하지 않고
JdbcTemplate을 사용할 수밖에 없었는데, 그 이유가 무엇이었는지 직접 검색해 알아보시면 많은 도움이 될 것 같아요. 저도 이번 기회에 batchInsert에 대해 많이 배웠네요!

2. 회원 저장 코드를 설정 저장 코드보다 앞에 배치해 2번 문제를 간단히 해결했습니다.

3. 3번 문제를 해결하기 위해 entityGraph를 사용했습니다.

4. 4번 문제를 해결하기 위해 Spring Data Jpa의 exists 메서드를 활용했습니다.

## 🌟 리뷰 요구 사항

개선 후 수행되는 쿼리입니다.

1.
```SQL
select m1_0.id from member m1_0 where m1_0.email='MooM8830@gmail.com' limit 1
```

2.
```SQL
select m1_0.id from member m1_0 where m1_0.nickname='MooM8830' limit 1
```

3.
```SQL
insert into member (created_at,deleted,email,modified_at,nickname,password,profile_image_info_id,social_id,social_type) values ('2023-10-03 01:25:34.957488',0,'MooM8830@gmail.com','2023-10-03 01:25:34.957488','MooM8830','$SPE1$1249429409$43c86939aebd2fc18bf17d2fd541ac7363bc084a631c137c53bb0ea480b9ae56',null,null,null)
```

4.
```SQL
insert into device (created_at,device_token,is_active,member_id,modified_at) values ('2023-10-03 01:25:34.96073','testDeviceToken',1,1502,'2023-10-03 01:25:34.96073')
```

5.
```SQL
select d1_0.id,d1_0.created_at,d1_0.device_token,d1_0.is_active,m1_0.id,m1_0.created_at,m1_0.deleted,m1_0.email,m1_0.modified_at,m1_0.nickname,m1_0.password,m1_0.profile_image_info_id,m1_0.social_id,m1_0.social_type,d1_0.modified_at from device d1_0 left join member m1_0 on m1_0.id=d1_0.member_id where d1_0.device_token='testDeviceToken'
```

6.
```SQL
update device set device_token='testDeviceToken',is_active=0,member_id=1501,modified_at='2023-10-03 01:25:35.041466' where id=1501
```

7.
```SQL
INSERT INTO setting (is_active, member_id, setting_type) values 
(0, 1502, 'NOTIFICATION_PER_THUMBS'),
(0, 1502, 'NOTIFICATION_PER_10_THUMBS'),
(0, 1502, 'NOTIFICATION_PER_COMMENT'),
(0, 1502, 'NOTIFICATION_CONSUMPTION_CONFIRMATION_REMINDING'),
(0, 1502, 'NOTIFICATION')
``

> 추가적으로 개선할 만한 점이 있는지 봐주세요!
