### PR TITLE
Refactor/#469 화질저하 리팩토링

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -48,7 +48,8 @@ android {
         )
 
         val kakaoNativeKey = localProperties.getProperty("KAKAO_NATIVE_KEY")
-        manifestPlaceholders["KAKAO_NATIVE_KEY"] = kakaoNativeKey.substring(1, kakaoNativeKey.length - 1)
+        manifestPlaceholders["KAKAO_NATIVE_KEY"] =
+            kakaoNativeKey.substring(1, kakaoNativeKey.length - 1)
     }
 
     buildTypes {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -67,14 +67,6 @@
             android:name="com.app.edonymyeon.presentation.ui.post.PostActivity"
             android:exported="true" />
 
-        <service
-            android:name="com.app.edonymyeon.data.service.fcm.AlarmService"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="com.google.firebase.MESSAGING_EVENT" />
-            </intent-filter>
-        </service>
-
         <activity
             android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
             android:exported="true">
@@ -89,5 +81,23 @@
                     android:scheme="${KAKAO_NATIVE_KEY}" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name="com.app.edonymyeon.data.service.fcm.AlarmService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 </manifest>

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/posteditor/PostEditorActivity.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/posteditor/PostEditorActivity.kt
@@ -2,13 +2,11 @@ package com.app.edonymyeon.presentation.ui.posteditor
 
 import android.Manifest
 import android.content.ClipData
-import android.content.ContentValues
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.provider.MediaStore
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuItem
@@ -30,7 +28,6 @@ import com.app.edonymyeon.presentation.util.makeSnackbarWithEvent
 import com.domain.edonymyeon.model.PostEditor
 import dagger.hilt.android.AndroidEntryPoint
 import java.io.File
-import java.time.LocalDateTime
 
 @AndroidEntryPoint
 class PostEditorActivity : BaseActivity<ActivityPostEditorBinding, PostEditorViewModel>(
@@ -195,8 +192,7 @@ class PostEditorActivity : BaseActivity<ActivityPostEditorBinding, PostEditorVie
     }
 
     private fun navigateToCamera() {
-        val photoFile =
-            File.createTempFile("IMG_", ".jpg", this.cacheDir)
+        val photoFile = File.createTempFile("IMG_", ".jpg", this.cacheDir)
         cameraUri = FileProvider.getUriForFile(this, "$packageName.provider", photoFile)
         takeCameraImage.launch(cameraUri)
     }
@@ -306,11 +302,6 @@ class PostEditorActivity : BaseActivity<ActivityPostEditorBinding, PostEditorVie
         const val POST_CODE = 2000
         const val UPDATE_CODE = 3000
         const val RESULT_RELOAD_CODE = 1001
-
-        private val contentValues = ContentValues().apply {
-            put(MediaStore.Images.Media.DISPLAY_NAME, "ImageTitle${LocalDateTime.now()}")
-            put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
-        }
 
         private val requestPermissions = arrayOf(
             Manifest.permission.WRITE_EXTERNAL_STORAGE,

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/posteditor/PostEditorActivity.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/posteditor/PostEditorActivity.kt
@@ -289,6 +289,16 @@ class PostEditorActivity : BaseActivity<ActivityPostEditorBinding, PostEditorVie
         finish()
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        if (!isChangingConfigurations) {
+            cameraUri?.let { uri ->
+                val contentResolver = applicationContext.contentResolver
+                contentResolver.delete(uri, null, null)
+            }
+        }
+    }
+
     companion object {
         private const val MAX_IMAGES_COUNT = 10
         private const val KEY_POST_EDITOR_CHECK = "key_post_editor_check"

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/posteditor/PostEditorActivity.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/posteditor/PostEditorActivity.kt
@@ -8,7 +8,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.os.Environment
 import android.provider.MediaStore
 import android.view.LayoutInflater
 import android.view.Menu
@@ -197,7 +196,7 @@ class PostEditorActivity : BaseActivity<ActivityPostEditorBinding, PostEditorVie
 
     private fun navigateToCamera() {
         val photoFile =
-            File.createTempFile("IMG_", ".jpg", getExternalFilesDir(Environment.DIRECTORY_PICTURES))
+            File.createTempFile("IMG_", ".jpg", this.cacheDir)
         cameraUri = FileProvider.getUriForFile(this, "$packageName.provider", photoFile)
         takeCameraImage.launch(cameraUri)
     }

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
-    <external-path
+    <cache-path
         name="my_images"
-        path="Android/data/app.edonymyeon/files/Pictures" />
+        path="./" />
 </paths>

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path
+        name="my_images"
+        path="Android/data/app.edonymyeon/files/Pictures" />
+</paths>

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
     <cache-path
-        name="my_images"
+        name="edonymyeon_images"
         path="./" />
 </paths>


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #469 

## 📝 작업 요약

사진을 촬영하여 올릴 시에 화질 저하 문제 개선

## 🔎 작업 상세 설명

이전에는 사진 촬영 시에 TakePicturePreview를 사용해서 사진의 썸네일 이미지를 Bitmap으로 얻어와 화질이 낮았던 문제가 생겼고 이를 개선함

## 🌟 리뷰 요구 사항

화질을 개선하는 방법이 카메라로 사진을 찍어서 그 사진을 저장한 후 uri를 통해 가져오는 방법 밖에 없는 것 같아서 그렇게 진행하였습니다! 
혹시  다른 좋은 방법이 있다면 알려주시면 감사하겠습니다😄 
Provider를 사용하여서 앱의 내부 캐시 저장소에 이미지를 임시 저장하도록 하고 갤러리에는 저장되지 않도록 하였습니다. 
캐시 저장소에 파일을 생성해서 이미지를 넣고 uri를 가져와서 launcher로 전달하기 위해서는 uri를 var 변수로 만들어야 했는데 혹시 더 좋은 방법이 있거나 리팩토링 해야할 부분이 있다면 알려주세요😊

그리고 카메라로 찍은 이미지가 회전하는 부분은 다른 pr에 넣어놔서 카메라 사진을 찍으면 회전이 되어서 나올겁니당😂
카메라 화질이 좋아졌는지도 확인 부탁드려요! 
애뮬레이터에서는 카메라를 찍어서 화질을 확인하는게 어려워서 갤럭시 노트 10+에서 확인했을 때는 화질이 좋았는데
다른 기기들도 확인해봐야할 것 같아여~!!
