### PR TITLE
Feat/#468 회원정보수정 뷰 구현

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
         applicationId = "app.edonymyeon"
         minSdk = 28
         targetSdk = 33
-        versionCode = 11
+        versionCode = 12
         versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -74,14 +74,6 @@
             android:name="com.app.edonymyeon.presentation.ui.post.PostActivity"
             android:exported="true" />
 
-        <service
-            android:name="com.app.edonymyeon.data.service.fcm.AlarmService"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="com.google.firebase.MESSAGING_EVENT" />
-            </intent-filter>
-        </service>
-
         <activity
             android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
             android:exported="true">
@@ -96,5 +88,23 @@
                     android:scheme="${KAKAO_NATIVE_KEY}" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name="com.app.edonymyeon.data.service.fcm.AlarmService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
+        <service android:name="com.google.android.gms.metadata.ModuleDependencies"
+            android:enabled="false"
+            android:exported="false"
+            tools:ignore="MissingClass">
+            <intent-filter>
+                <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
+            </intent-filter>
+            <meta-data android:name="photopicker_activity:0:required" android:value="" />
+        </service>
     </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,9 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
+            android:name="com.app.edonymyeon.presentation.ui.profileupdate.ProfileUpdateActivity"
+            android:exported="false" />
+        <activity
             android:name="com.app.edonymyeon.presentation.ui.alarmsetting.AlarmSettingActivity"
             android:exported="false" />
         <activity
@@ -39,8 +42,8 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="POST" />
-                <category android:name="android.intent.category.DEFAULT" />
 
+                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
         <activity
@@ -51,6 +54,7 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
@@ -59,8 +63,8 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="MYPOST" />
-                <category android:name="android.intent.category.DEFAULT" />
 
+                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
         <activity

--- a/android/app/src/main/java/com/app/edonymyeon/data/datasource/auth/AuthRemoteDataSource.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/data/datasource/auth/AuthRemoteDataSource.kt
@@ -1,6 +1,5 @@
 package com.app.edonymyeon.data.datasource.auth
 
-import android.util.Log
 import com.app.edonymyeon.data.dto.LoginDataModel
 import com.app.edonymyeon.data.dto.request.LogoutRequest
 import com.app.edonymyeon.data.dto.request.TokenRequest
@@ -30,7 +29,6 @@ class AuthRemoteDataSource @Inject constructor(
     }
 
     override suspend fun logout(logoutRequest: LogoutRequest): Response<Unit> {
-        Log.d("testLog", logoutRequest.deviceToken)
         return authService.logout(logoutRequest)
     }
 

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/mypage/MyPageFragment.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/mypage/MyPageFragment.kt
@@ -15,8 +15,8 @@ import com.app.edonymyeon.presentation.ui.main.MainActivity
 import com.app.edonymyeon.presentation.ui.main.mypage.chart.LineChartManager
 import com.app.edonymyeon.presentation.ui.main.mypage.dialog.WithdrawDialog
 import com.app.edonymyeon.presentation.ui.mypost.MyPostActivity
+import com.app.edonymyeon.presentation.ui.profileupdate.ProfileUpdateActivity
 import com.app.edonymyeon.presentation.uimodel.NicknameUiModel
-import com.app.edonymyeon.presentation.util.makeSnackbar
 import com.app.edonymyeon.presentation.util.makeSnackbarWithEvent
 import com.github.mikephil.charting.data.Entry
 import com.github.mikephil.charting.data.LineData
@@ -24,9 +24,7 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MyPageFragment : BaseFragment<FragmentMyPageBinding, MyPageViewModel>(
-    {
-        FragmentMyPageBinding.inflate(it)
-    },
+    { FragmentMyPageBinding.inflate(it) },
 ) {
     override val viewModel: MyPageViewModel by viewModels()
     override val inflater: LayoutInflater by lazy { LayoutInflater.from(context) }
@@ -107,7 +105,7 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding, MyPageViewModel>(
         binding.tvLogout.setOnClickListener { logout() }
         binding.tvMyPost.setOnClickListener { navigateToMyPost() }
         binding.tvUpdateAlarmSetting.setOnClickListener { navigateToAlarmSetting() }
-        binding.tvUpdateUserInfo.setOnClickListener { binding.root.makeSnackbar(getString(R.string.all_preparing_feature)) }
+        binding.tvUpdateUserInfo.setOnClickListener { navigateToProfileUpdate() }
         binding.tvWithdraw.setOnClickListener { showDialog() }
     }
 
@@ -164,6 +162,10 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding, MyPageViewModel>(
     private fun navigateToAlarmSetting() {
 //        binding.root.makeSnackbar(getString(R.string.all_preparing_feature))
         startActivity(AlarmSettingActivity.newIntent(requireContext()))
+    }
+
+    private fun navigateToProfileUpdate() {
+        startActivity(ProfileUpdateActivity.newIntent(requireContext()))
     }
 
     private fun navigateToLogin() {

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/mypage/MyPageFragment.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/mypage/MyPageFragment.kt
@@ -160,12 +160,11 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding, MyPageViewModel>(
     }
 
     private fun navigateToAlarmSetting() {
-//        binding.root.makeSnackbar(getString(R.string.all_preparing_feature))
         startActivity(AlarmSettingActivity.newIntent(requireContext()))
     }
 
     private fun navigateToProfileUpdate() {
-        startActivity(ProfileUpdateActivity.newIntent(requireContext()))
+        startActivity(ProfileUpdateActivity.newIntent(requireContext(), viewModel.profile.value!!))
     }
 
     private fun navigateToLogin() {

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/posteditor/adapter/PostEditorImagesAdapter.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/posteditor/adapter/PostEditorImagesAdapter.kt
@@ -1,6 +1,5 @@
 package com.app.edonymyeon.presentation.ui.posteditor.adapter
 
-import android.util.Log
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import com.app.edonymyeon.presentation.ui.posteditor.viewholder.PostEditorImagesViewHolder
@@ -17,7 +16,6 @@ class PostEditorImagesAdapter(
     }
 
     fun setImages(images: List<String>) {
-        Log.d("post", "submit Images into adapter: ${images.size}")
         submitList(images)
     }
 }

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateActivity.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateActivity.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import app.edonymyeon.databinding.ActivityProfileUpdateBinding
 import com.app.edonymyeon.presentation.common.activity.BaseActivity
@@ -21,11 +23,19 @@ class ProfileUpdateActivity : BaseActivity<ActivityProfileUpdateBinding, Profile
             ?: throw IllegalArgumentException()
     }
 
+    private val pickMultipleImage =
+        registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
+            if (uri != null) {
+                viewModel.setNewProfileImage(uri.toString())
+            }
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
         initBinding()
         setOriginalProfile()
+        setImageButtonsClickListener()
     }
 
     private fun initBinding() {
@@ -35,6 +45,19 @@ class ProfileUpdateActivity : BaseActivity<ActivityProfileUpdateBinding, Profile
 
     private fun setOriginalProfile() {
         viewModel.initOriginalProfile(originalProfile)
+    }
+
+    private fun setImageButtonsClickListener() {
+        binding.btnImageUpload.setOnClickListener {
+            navigateToGallery()
+        }
+        binding.btnImageDelete.setOnClickListener {
+            // TODO: 이미지 삭제
+        }
+    }
+
+    private fun navigateToGallery() {
+        pickMultipleImage.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
     }
 
     companion object {

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateActivity.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateActivity.kt
@@ -7,22 +7,43 @@ import android.view.LayoutInflater
 import androidx.activity.viewModels
 import app.edonymyeon.databinding.ActivityProfileUpdateBinding
 import com.app.edonymyeon.presentation.common.activity.BaseActivity
+import com.app.edonymyeon.presentation.uimodel.WriterUiModel
+import com.app.edonymyeon.presentation.util.getParcelableExtraCompat
 
 class ProfileUpdateActivity : BaseActivity<ActivityProfileUpdateBinding, ProfileUpdateViewModel>(
     { ActivityProfileUpdateBinding.inflate(it) },
 ) {
     override val viewModel: ProfileUpdateViewModel by viewModels()
-
     override val inflater: LayoutInflater by lazy { LayoutInflater.from(this) }
+
+    private val originalProfile by lazy {
+        intent.getParcelableExtraCompat(KEY_PROFILE) as? WriterUiModel
+            ?: throw IllegalArgumentException()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
+        initBinding()
+        setOriginalProfile()
+    }
+
+    private fun initBinding() {
+        binding.lifecycleOwner = this
+        binding.viewModel = viewModel
+    }
+
+    private fun setOriginalProfile() {
+        viewModel.initOriginalProfile(originalProfile)
     }
 
     companion object {
-        fun newIntent(context: Context): Intent {
-            return Intent(context, ProfileUpdateActivity::class.java)
+        private const val KEY_PROFILE = "key_profile"
+
+        fun newIntent(context: Context, profile: WriterUiModel): Intent {
+            return Intent(context, ProfileUpdateActivity::class.java).apply {
+                putExtra(KEY_PROFILE, profile)
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateActivity.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateActivity.kt
@@ -52,7 +52,7 @@ class ProfileUpdateActivity : BaseActivity<ActivityProfileUpdateBinding, Profile
             navigateToGallery()
         }
         binding.btnImageDelete.setOnClickListener {
-            // TODO: 이미지 삭제
+            viewModel.deleteProfileImage()
         }
     }
 

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateActivity.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateActivity.kt
@@ -1,0 +1,22 @@
+package com.app.edonymyeon.presentation.ui.profileupdate
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import app.edonymyeon.databinding.ActivityProfileUpdateBinding
+
+class ProfileUpdateActivity : AppCompatActivity() {
+    private val binding by lazy { ActivityProfileUpdateBinding.inflate(layoutInflater) }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+    }
+
+    companion object {
+        fun newIntent(context: Context): Intent {
+            return Intent(context, ProfileUpdateActivity::class.java)
+        }
+    }
+}

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateActivity.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateActivity.kt
@@ -11,7 +11,9 @@ import app.edonymyeon.databinding.ActivityProfileUpdateBinding
 import com.app.edonymyeon.presentation.common.activity.BaseActivity
 import com.app.edonymyeon.presentation.uimodel.WriterUiModel
 import com.app.edonymyeon.presentation.util.getParcelableExtraCompat
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class ProfileUpdateActivity : BaseActivity<ActivityProfileUpdateBinding, ProfileUpdateViewModel>(
     { ActivityProfileUpdateBinding.inflate(it) },
 ) {

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateActivity.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateActivity.kt
@@ -3,11 +3,17 @@ package com.app.edonymyeon.presentation.ui.profileupdate
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
+import android.view.LayoutInflater
+import androidx.activity.viewModels
 import app.edonymyeon.databinding.ActivityProfileUpdateBinding
+import com.app.edonymyeon.presentation.common.activity.BaseActivity
 
-class ProfileUpdateActivity : AppCompatActivity() {
-    private val binding by lazy { ActivityProfileUpdateBinding.inflate(layoutInflater) }
+class ProfileUpdateActivity : BaseActivity<ActivityProfileUpdateBinding, ProfileUpdateViewModel>(
+    { ActivityProfileUpdateBinding.inflate(it) },
+) {
+    override val viewModel: ProfileUpdateViewModel by viewModels()
+
+    override val inflater: LayoutInflater by lazy { LayoutInflater.from(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateViewModel.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateViewModel.kt
@@ -1,0 +1,5 @@
+package com.app.edonymyeon.presentation.ui.profileupdate
+
+import com.app.edonymyeon.presentation.common.viewmodel.BaseViewModel
+
+class ProfileUpdateViewModel : BaseViewModel()

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateViewModel.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateViewModel.kt
@@ -1,5 +1,6 @@
 package com.app.edonymyeon.presentation.ui.profileupdate
 
+import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.app.edonymyeon.presentation.common.viewmodel.BaseViewModel
@@ -10,7 +11,20 @@ class ProfileUpdateViewModel : BaseViewModel() {
     val profile: LiveData<WriterUiModel>
         get() = _profile
 
+    private val _newProfileImage = MutableLiveData<String?>()
+    val newProfileImage: LiveData<String?>
+        get() = _newProfileImage
+
+    init {
+        _newProfileImage.value = null
+    }
+
     fun initOriginalProfile(original: WriterUiModel) {
         _profile.value = WriterUiModel(original.id, original.nickname, original.profileImage)
+        _newProfileImage.value = original.profileImage
+    }
+
+    fun setNewProfileImage(image: String) {
+        _newProfileImage.value = image
     }
 }

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateViewModel.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateViewModel.kt
@@ -1,5 +1,16 @@
 package com.app.edonymyeon.presentation.ui.profileupdate
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import com.app.edonymyeon.presentation.common.viewmodel.BaseViewModel
+import com.app.edonymyeon.presentation.uimodel.WriterUiModel
 
-class ProfileUpdateViewModel : BaseViewModel()
+class ProfileUpdateViewModel : BaseViewModel() {
+    private val _profile = MutableLiveData<WriterUiModel>()
+    val profile: LiveData<WriterUiModel>
+        get() = _profile
+
+    fun initOriginalProfile(original: WriterUiModel) {
+        _profile.value = WriterUiModel(original.id, original.nickname, original.profileImage)
+    }
+}

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateViewModel.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateViewModel.kt
@@ -1,6 +1,5 @@
 package com.app.edonymyeon.presentation.ui.profileupdate
 
-import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.app.edonymyeon.presentation.common.viewmodel.BaseViewModel
@@ -26,5 +25,9 @@ class ProfileUpdateViewModel : BaseViewModel() {
 
     fun setNewProfileImage(image: String) {
         _newProfileImage.value = image
+    }
+
+    fun deleteProfileImage() {
+        _newProfileImage.value = null
     }
 }

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateViewModel.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateViewModel.kt
@@ -20,10 +20,6 @@ class ProfileUpdateViewModel @Inject constructor(
     val newProfileImage: LiveData<String?>
         get() = _newProfileImage
 
-    init {
-        _newProfileImage.value = null
-    }
-
     fun initOriginalProfile(original: WriterUiModel) {
         _profile.value = WriterUiModel(original.id, original.nickname, original.profileImage)
         _newProfileImage.value = original.profileImage

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateViewModel.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/profileupdate/ProfileUpdateViewModel.kt
@@ -4,8 +4,14 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.app.edonymyeon.presentation.common.viewmodel.BaseViewModel
 import com.app.edonymyeon.presentation.uimodel.WriterUiModel
+import com.domain.edonymyeon.repository.ProfileRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
-class ProfileUpdateViewModel : BaseViewModel() {
+@HiltViewModel
+class ProfileUpdateViewModel @Inject constructor(
+    private val repository: ProfileRepository,
+) : BaseViewModel() {
     private val _profile = MutableLiveData<WriterUiModel>()
     val profile: LiveData<WriterUiModel>
         get() = _profile

--- a/android/app/src/main/res/drawable/bg_666666_radius_6dp.xml
+++ b/android/app/src/main/res/drawable/bg_666666_radius_6dp.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="6dp" />
+    <solid android:color="@color/gray_666666" />
+</shape>

--- a/android/app/src/main/res/layout/activity_profile_update.xml
+++ b/android/app/src/main/res/layout/activity_profile_update.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <Space
+            android:id="@+id/space_image_top"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="H,360:64"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/iv_profile"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="H,1:1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/space_image_top"
+            app:layout_constraintWidth_percent="0.54"
+            tools:src="@drawable/ic_launcher_background" />
+
+        <Space
+            android:id="@+id/space_image_bottom"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="H,360:36"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/iv_profile" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_image_upload"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@drawable/bg_576b9e_radius_6dp"
+            android:text="@string/profile_update_image_upload"
+            android:textColor="@color/white_ffffff"
+            android:textSize="16sp"
+            app:layout_constraintDimensionRatio="H,140:42"
+            app:layout_constraintEnd_toStartOf="@id/btn_image_delete"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/space_image_bottom"
+            app:layout_constraintWidth_percent="0.4" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_image_delete"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@drawable/bg_666666_radius_6dp"
+            android:text="@string/profile_update_image_delete"
+            android:textColor="@color/white_ffffff"
+            android:textSize="16sp"
+            app:layout_constraintDimensionRatio="H,140:42"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/btn_image_upload"
+            app:layout_constraintTop_toBottomOf="@id/space_image_bottom"
+            app:layout_constraintWidth_percent="0.4" />
+
+        <Space
+            android:id="@+id/space_button_bottom"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="H,360:30"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/btn_image_upload" />
+
+        <Space
+            android:id="@+id/space_field_start"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="H,360:32"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/space_button_bottom" />
+
+        <Space
+            android:id="@+id/space_field_end"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="H,360:32"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/space_button_bottom" />
+
+        <TextView
+            android:id="@+id/tv_title_nickname"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/profile_update_nickname_title"
+            android:textColor="@color/black_434343"
+            android:textSize="16sp"
+            app:layout_constraintStart_toEndOf="@id/space_field_start"
+            app:layout_constraintTop_toBottomOf="@id/space_button_bottom" />
+
+        <Space
+            android:id="@+id/space_nickname_bottom"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="H,360:14"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_title_nickname" />
+
+        <EditText
+            android:id="@+id/et_nickname"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@drawable/bg_stroke_576b9e_radius_10dp"
+            android:inputType="text"
+            android:padding="10dp"
+            android:textColor="@color/black_000000"
+            android:textColorHint="@color/black_000000"
+            android:textSize="16sp"
+            app:layout_constraintDimensionRatio="H,270:36"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/space_nickname_bottom"
+            app:layout_constraintWidth_percent="0.88" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/activity_profile_update.xml
+++ b/android/app/src/main/res/layout/activity_profile_update.xml
@@ -3,6 +3,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.app.edonymyeon.presentation.ui.profileupdate.ProfileUpdateViewModel" />
+    </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -18,8 +25,10 @@
 
         <ImageView
             android:id="@+id/iv_profile"
+            imgUrlCircleCrop="@{viewModel.profile.profileImage}"
             android:layout_width="0dp"
             android:layout_height="0dp"
+            android:background="@drawable/bg_stroke_576b9e_oval"
             app:layout_constraintDimensionRatio="H,1:1"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -114,11 +123,12 @@
             android:id="@+id/et_nickname"
             android:layout_width="0dp"
             android:layout_height="0dp"
+            android:autofillHints="no"
             android:background="@drawable/bg_stroke_576b9e_radius_10dp"
             android:inputType="text"
             android:padding="10dp"
-            android:textColor="@color/black_000000"
-            android:textColorHint="@color/black_000000"
+            android:text="@{viewModel.profile.nickname.toString()}"
+            android:textColor="@color/gray_434343"
             android:textSize="16sp"
             app:layout_constraintDimensionRatio="H,270:36"
             app:layout_constraintEnd_toEndOf="parent"
@@ -145,10 +155,10 @@
             android:id="@+id/space_update_bottom"
             android:layout_width="0dp"
             android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintDimensionRatio="H,360:14"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"/>
+            app:layout_constraintStart_toStartOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout/activity_profile_update.xml
+++ b/android/app/src/main/res/layout/activity_profile_update.xml
@@ -25,7 +25,7 @@
 
         <ImageView
             android:id="@+id/iv_profile"
-            imgUrlCircleCrop="@{viewModel.profile.profileImage}"
+            imgUrlCircleCrop="@{viewModel.newProfileImage}"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:background="@drawable/bg_stroke_576b9e_oval"

--- a/android/app/src/main/res/layout/activity_profile_update.xml
+++ b/android/app/src/main/res/layout/activity_profile_update.xml
@@ -126,5 +126,29 @@
             app:layout_constraintTop_toBottomOf="@id/space_nickname_bottom"
             app:layout_constraintWidth_percent="0.88" />
 
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_update"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@drawable/bg_576b9e_radius_6dp"
+            android:stateListAnimator="@null"
+            android:text="@string/profile_update_button_update"
+            android:textColor="@color/white_ffffff"
+            android:textSize="16sp"
+            app:layout_constraintBottom_toTopOf="@id/space_update_bottom"
+            app:layout_constraintDimensionRatio="H,320:48"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintWidth_percent="0.88" />
+
+        <Space
+            android:id="@+id/space_update_bottom"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintDimensionRatio="H,360:14"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout/activity_sign_up.xml
+++ b/android/app/src/main/res/layout/activity_sign_up.xml
@@ -410,7 +410,6 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/bt_join" />
 
-
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 </layout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="post_detail_login_required">추천 기능은 회원만 이용할 수 있습니다.</string>
     <string name="post_detail_input_comment">댓글을 입력하세요.</string>
     <string name="post_detail_gallery_content_description">갤러리에 접근할 수 있는 버튼입니다.</string>
+    <string name="post_detail_comment_title">댓글</string>
 
     <!-- post detail dialog -->
     <string name="post_detail_dialog_title">정말로 삭제하시겠습니까?</string>
@@ -51,7 +52,7 @@
     <string name="post_detail_deleted_dialog_title">삭제된 게시글입니다</string>
     <string name="post_detail_deleted_dialog_yes">확인</string>
 
-    <!--post report dialog -->
+    <!-- post report dialog -->
     <string name="post_report_dialog_title">신고 사유</string>
     <string name="post_report_dialog_description">허위신고일 경우, 신고자의 서비스 활동이 제한 될 수 있으니 신중하게 신고해 주세요</string>
     <string name="post_report_dialog_input_reason">신고 사유를 입력하세요.</string>
@@ -63,7 +64,7 @@
     <string name="post_report_dialog_report_repeat">같은 내용 반복(도배)</string>
     <string name="post_report_dialog_report_etc">기타</string>
 
-    <!-- my page   -->
+    <!-- my page -->
     <string name="my_page_title">마이페이지</string>
     <string name="my_page_payment_title">월 별 소비/절약 그래프</string>
     <string name="my_page_my_post">내가 쓴 글 및 소비/절약 확정</string>
@@ -81,13 +82,13 @@
     <string name="my_page_price">%,d원</string>
     <string name="my_page_loading_data">데이터를 불러오고 있습니다.</string>
 
-    <!-- withdraw dialog-->
+    <!-- withdraw dialog -->
     <string name="withdraw_dialog_content">탈퇴 버튼 선택 시, 계정은\n삭제되며 복구되지 않습니다.</string>
     <string name="withdraw_dialog_title">정말 탈퇴하실건가요?</string>
     <string name="withdraw_dialog_ok">탈퇴</string>
     <string name="withdraw_dialog_cancel">남을래요</string>
 
-    <!--post_editor-->
+    <!-- post_editor -->
     <string name="post_editor_page_title">글쓰기</string>
     <string name="post_editor_post_title">제목</string>
     <string name="post_editor_post_title_hint">제목을 입력하세요</string>
@@ -104,14 +105,14 @@
     <string name="post_editor_snackbar_missing_title_message">타이틀을 작성해야만 등록이 됩니다.</string>
     <string name="post_editor_loading_message">저장 중입니다</string>
 
-    <!--item_post_editor_image-->
+    <!-- item_post_editor_image -->
     <string name="item_post_editor_image_description">갤러리에서 가져온 이미지</string>
     <string name="item_post_editor_image_delete_description">이미지 삭제 버튼</string>
 
-    <!--all_post-->
+    <!-- all_post -->
     <string name="post_all_post">전체 게시물</string>
 
-    <!--my_post-->
+    <!-- my_post -->
     <string name="my_post_page_title">내가 쓴 글 및 소비/절약 확정</string>
     <string name="my_post_consumption_purchase">샀어요</string>
     <string name="my_post_consumption_not_purchase">안샀어요</string>
@@ -121,7 +122,7 @@
     <string name="my_post_purchase_text">%,d원 구매확정</string>
     <string name="my_post_saving_text">절약확정</string>
 
-    <!--my_post_dialog-->
+    <!-- my_post_dialog -->
     <string name="dialog_purchase_title">구매 금액과 날짜를 입력해주세요</string>
     <string name="dialog_saving_title">절약을 결심한 날짜를 입력해주세요</string>
     <string name="dialog_consumption_cancel">취소</string>
@@ -129,7 +130,7 @@
     <string name="dialog_input_price_hint">금액입력</string>
     <string name="dialog_input_price_error_message">입력될 수 있는 금액 초과</string>
 
-    <!--sign_up-->
+    <!-- sign_up -->
     <string name="sign_up_nickname">닉네임</string>
     <string name="sign_up_email">이메일</string>
     <string name="sign_up_matching_password">일치</string>
@@ -141,7 +142,7 @@
     <string name="sign_up_nickname_policy">* 1~20자 이내로 가능합니다</string>
     <string name="sign_up_password_policy">* 8~30자, 알파벳, 숫자, 특수기호\n 모두 1개 이상 포함되어야 합니다.</string>
 
-    <!--alarm_setting-->
+    <!-- alarm_setting -->
     <string name="alarm_setting_tool_bar_title">푸시 알림 설정</string>
     <string name="alarm_setting_title">푸시 알림 수신</string>
     <string name="alarm_setting_content">해제하면 푸시 알림을 수신할 수 없습니다.</string>
@@ -151,10 +152,13 @@
     <string name="alarm_setting_request_alarm_permission">알림 권한을 허용해주세요.</string>
     <string name="alarm_setting_comment">댓글 알림 수신</string>
 
-    <!--alarm-->
+    <!-- alarm -->
     <string name="alarm_title">알림</string>
     <string name="alarm_period_explanation">최근 3개월 내  푸시 알림 내역입니다</string>
-    <string name="post_detail_comment_title">댓글</string>
 
+    <!-- profile update -->
+    <string name="profile_update_image_upload">프로필 사진 업로드</string>
+    <string name="profile_update_image_delete">기본 이미지로 변경</string>
+    <string name="profile_update_nickname_title">닉네임</string>
 
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -160,5 +160,6 @@
     <string name="profile_update_image_upload">프로필 사진 업로드</string>
     <string name="profile_update_image_delete">기본 이미지로 변경</string>
     <string name="profile_update_nickname_title">닉네임</string>
+    <string name="profile_update_button_update">수정하기</string>
 
 </resources>


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #468 

## 📝 작업 요약

회원정보수정 뷰 구현

## 🔎 작업 상세 설명

회원정보수정 뷰를 구현했습니다.
또한 기존 회원정보가 뷰에 보이도록 했어요.

연휴동안 api까지 해서 올리려고 했는데, 아직 api 배포가 되지 않아서 이 부분은 추후 실제 잘 되는지까지 확인해서 올릴게요.
우선 뷰 먼저 리뷰 요청 보냅니다!

## 🌟 리뷰 요구 사항

> 뷰,,라서 오래 걸릴 것 같진 않습니다..!  api 배포 전까지 머지되면 좋겠네요 😆 
 
사진 선택 부분은 `PickVisualMedia`를 이용했습니다.
- 갤러리 관련하여 별도의 권한을 요구하지 않는다는 장점이 있고,
- SDK 버전이 30 미만이거나, SDK Extensions의 버전이 2미만일 경우에는 ACTION_OPEN_DOCUMENT가 자동으로 실행되므로 버전 문제도 없을 것으로 보여요.
- 프로필 사진 선택이라 딱 한 장만 빠르게 쉭쉭 고를 수 있어 좋은 것 같구요.

ref.
https://developer.android.com/training/data-storage/shared/photopicker?hl=ko 
https://developer.android.com/reference/kotlin/androidx/activity/result/contract/ActivityResultContracts.PickVisualMedia 

여러분의 의견은 어떠신가요?