### PR TITLE
Refactor/#523 회원 엔티티 속성 값객체분리

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
+++ b/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
@@ -123,8 +123,7 @@ public class AuthService {
     }
 
     private Member saveMember(Member member) {
-        final String encodedPassword = passwordEncoder.encode(member.getPassword());
-        member.encrypt(encodedPassword);
+        member.encrypt(passwordEncoder);
         return memberRepository.save(member);
     }
 

--- a/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
+++ b/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
@@ -20,6 +20,7 @@ import edonymyeon.backend.member.application.MemberService;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.application.dto.MemberId;
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.domain.Nickname;
 import edonymyeon.backend.member.domain.SocialInfo;
 import edonymyeon.backend.member.domain.SocialInfo.SocialType;
 import edonymyeon.backend.member.repository.MemberRepository;
@@ -156,7 +157,7 @@ public class AuthService {
     }
 
     private void validateDuplicateNickname(final String nickname) {
-        if (memberRepository.existsByNickname(nickname)) {
+        if (memberRepository.existsByNickname(Nickname.from(nickname))) {
             throw new EdonymyeonException(MEMBER_NICKNAME_INVALID);
         }
     }

--- a/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
+++ b/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
@@ -19,6 +19,7 @@ import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.member.application.MemberService;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.application.dto.MemberId;
+import edonymyeon.backend.member.domain.Email;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.domain.Nickname;
 import edonymyeon.backend.member.domain.SocialInfo;
@@ -63,7 +64,7 @@ public class AuthService {
     }
 
     private Member findByEmail(final String email) {
-        final Member member = memberRepository.findByEmail(email)
+        final Member member = memberRepository.findByEmail(Email.from(email))
                 .orElseThrow(() -> new EdonymyeonException(MEMBER_EMAIL_NOT_FOUND));
         if (member.isDeleted()) {
             throw new EdonymyeonException(MEMBER_IS_DELETED);
@@ -151,7 +152,7 @@ public class AuthService {
     }
 
     private void validateDuplicateEmail(final String email) {
-        if (memberRepository.existsByEmail(email)) {
+        if (memberRepository.existsByEmail(Email.from(email))) {
             throw new EdonymyeonException(MEMBER_EMAIL_DUPLICATE);
         }
     }

--- a/backend/src/main/java/edonymyeon/backend/global/exception/ExceptionInformation.java
+++ b/backend/src/main/java/edonymyeon/backend/global/exception/ExceptionInformation.java
@@ -24,7 +24,7 @@ public enum ExceptionInformation {
     LOGOUT_FAILED(1525, "로그아웃에 실패하였습니다."),
     NOT_SUPPORTED_VERSION(1526, "지원하지 않는 버전입니다."),
     NOT_SUPPORTED_ALGORITHM(1527, "현재 지원하지 않는 알고리즘입니다."),
-    ENCODED_PASSWORD_INVALID(1528, "잘못 인코딩된 비밀번호입니다."),
+    ALREADY_ENCODED_PASSWORD(1528, "이미 암호화된 비밀번호입니다."),
 
     // 2___: 게시글 관련
     POST_ID_NOT_FOUND(2000, "존재하지 않는 게시글입니다."),

--- a/backend/src/main/java/edonymyeon/backend/member/application/MemberService.java
+++ b/backend/src/main/java/edonymyeon/backend/member/application/MemberService.java
@@ -22,6 +22,7 @@ import edonymyeon.backend.member.application.dto.response.MyPageResponseV1_1;
 import edonymyeon.backend.member.application.event.ProfileImageDeletionEvent;
 import edonymyeon.backend.member.domain.Device;
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.domain.Nickname;
 import edonymyeon.backend.member.repository.MemberRepository;
 import java.util.Objects;
 import java.util.Optional;
@@ -88,7 +89,7 @@ public class MemberService {
 
     private void validateDuplicateNickname(final String currentNickname, final String updateNickname) {
         if (!currentNickname.equals(updateNickname) &&
-                memberRepository.existsByNickname(updateNickname)) {
+                memberRepository.existsByNickname(Nickname.from(updateNickname))) {
             throw new EdonymyeonException(MEMBER_NICKNAME_DUPLICATE);
         }
     }
@@ -107,7 +108,7 @@ public class MemberService {
             return memberRepository.existsByEmail(value);
         }
 
-        return memberRepository.existsByNickname(value);
+        return memberRepository.existsByNickname(Nickname.from(value));
     }
 
     @Transactional

--- a/backend/src/main/java/edonymyeon/backend/member/application/MemberService.java
+++ b/backend/src/main/java/edonymyeon/backend/member/application/MemberService.java
@@ -21,6 +21,7 @@ import edonymyeon.backend.member.application.dto.response.MyPageResponseV1_0;
 import edonymyeon.backend.member.application.dto.response.MyPageResponseV1_1;
 import edonymyeon.backend.member.application.event.ProfileImageDeletionEvent;
 import edonymyeon.backend.member.domain.Device;
+import edonymyeon.backend.member.domain.Email;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.domain.Nickname;
 import edonymyeon.backend.member.repository.MemberRepository;
@@ -105,7 +106,7 @@ public class MemberService {
 
     private boolean existsByValidateType(final ValidateType validateType, final String value) {
         if (validateType.equals(ValidateType.EMAIL)) {
-            return memberRepository.existsByEmail(value);
+            return memberRepository.existsByEmail(Email.from(value));
         }
 
         return memberRepository.existsByNickname(Nickname.from(value));

--- a/backend/src/main/java/edonymyeon/backend/member/domain/Email.java
+++ b/backend/src/main/java/edonymyeon/backend/member/domain/Email.java
@@ -1,0 +1,47 @@
+package edonymyeon.backend.member.domain;
+
+import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_EMAIL_INVALID;
+import static edonymyeon.backend.member.domain.SocialInfo.*;
+
+import edonymyeon.backend.global.exception.EdonymyeonException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.apache.logging.log4j.util.Strings;
+
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class Email {
+
+    private static final int MAX_EMAIL_LENGTH = 30;
+
+    @Column(name = "email", nullable = false, unique = true)
+    private String value;
+
+    private Email(String email) {
+        this.value = email;
+    }
+
+    public static Email from(String email) {
+        validate(email);
+        return new Email(email);
+    }
+
+    private static void validate(final String email) {
+        if (Strings.isBlank(email) || email.length() > MAX_EMAIL_LENGTH) {
+            throw new EdonymyeonException(MEMBER_EMAIL_INVALID);
+        }
+    }
+
+    public static Email from(final SocialType socialType) {
+        return new Email("#" + socialType.name() + UUID.randomUUID());
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/backend/src/main/java/edonymyeon/backend/member/domain/Nickname.java
+++ b/backend/src/main/java/edonymyeon/backend/member/domain/Nickname.java
@@ -1,0 +1,49 @@
+package edonymyeon.backend.member.domain;
+
+import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_NICKNAME_INVALID;
+import static edonymyeon.backend.member.domain.SocialInfo.*;
+
+import edonymyeon.backend.global.exception.EdonymyeonException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.apache.logging.log4j.util.Strings;
+
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public final class Nickname {
+
+    public static final String NONE = "Unknown";
+    private static final int MAX_NICKNAME_LENGTH = 20;
+
+    @Column(name = "nickname", nullable = false, unique = true)
+    private String value;
+
+    private Nickname(final String nickname) {
+        this.value = nickname;
+    }
+
+    public static Nickname from(final String nickname) {
+        validate(nickname);
+        return new Nickname(nickname);
+    }
+
+    private static void validate(final String nickname) {
+        if (Strings.isBlank(nickname) || nickname.length() > MAX_NICKNAME_LENGTH
+                || nickname.equalsIgnoreCase(NONE)) {
+            throw new EdonymyeonException(MEMBER_NICKNAME_INVALID);
+        }
+    }
+
+    public static Nickname from(final SocialType socialType) {
+        return new Nickname("#" + socialType.name() + UUID.randomUUID());
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/backend/src/main/java/edonymyeon/backend/member/domain/Password.java
+++ b/backend/src/main/java/edonymyeon/backend/member/domain/Password.java
@@ -1,0 +1,52 @@
+package edonymyeon.backend.member.domain;
+
+import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_PASSWORD_INVALID;
+import static edonymyeon.backend.member.domain.SocialInfo.SocialType;
+
+import edonymyeon.backend.auth.domain.PasswordEncoder;
+import edonymyeon.backend.global.exception.EdonymyeonException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class Password {
+
+    @Column(name = "password", nullable = false)
+    private String value;
+
+    private Password(final String value) {
+        this.value = value;
+    }
+
+    public static Password from(final String password) {
+        validate(password);
+        return new Password(password);
+    }
+
+    private static void validate(final String password) {
+        if (PasswordValidator.isValidPassword(password)) {
+            return;
+        }
+        throw new EdonymyeonException(MEMBER_PASSWORD_INVALID);
+    }
+
+    public static Password from(final SocialType socialType) {
+        final String uuid = "#" + socialType.name() + UUID.randomUUID();
+        final String defaultPassword = uuid.replace("-", "").substring(0, 25) + "!";
+        return new Password(defaultPassword);
+    }
+
+    public Password encrypt(final PasswordEncoder passwordEncoder) {
+        return new Password(passwordEncoder.encode(value));
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/backend/src/main/java/edonymyeon/backend/member/domain/Password.java
+++ b/backend/src/main/java/edonymyeon/backend/member/domain/Password.java
@@ -4,7 +4,9 @@ import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_PA
 import static edonymyeon.backend.member.domain.SocialInfo.SocialType;
 
 import edonymyeon.backend.auth.domain.PasswordEncoder;
+import edonymyeon.backend.global.exception.BusinessLogicException;
 import edonymyeon.backend.global.exception.EdonymyeonException;
+import edonymyeon.backend.global.exception.ExceptionInformation;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.util.UUID;
@@ -43,6 +45,9 @@ public class Password {
     }
 
     public Password encrypt(final PasswordEncoder passwordEncoder) {
+        if (PasswordValidator.isEncodedPassword(value)) {
+            throw new BusinessLogicException(ExceptionInformation.ALREADY_ENCODED_PASSWORD);
+        }
         return new Password(passwordEncoder.encode(value));
     }
 

--- a/backend/src/main/java/edonymyeon/backend/member/domain/PasswordValidator.java
+++ b/backend/src/main/java/edonymyeon/backend/member/domain/PasswordValidator.java
@@ -9,22 +9,13 @@ public class PasswordValidator {
     }
 
     private static final String PASSWORD_PATTERN = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,30}$";
-    private static final String ENCODED_PATTERN = "^\\$.+\\$.+\\$.+";
 
     private static final Pattern passwordPattern = Pattern.compile(PASSWORD_PATTERN);
-    private static final Pattern encodedPattern = Pattern.compile(ENCODED_PATTERN);
 
     public static boolean isValidPassword(String password) {
         if (Objects.isNull(password) || password.isBlank()) {
             return false;
         }
         return passwordPattern.matcher(password).matches();
-    }
-
-    public static boolean isValidEncodedPassword(String encodedPassword) {
-        if (Objects.isNull(encodedPassword) || encodedPassword.isBlank()) {
-            return false;
-        }
-        return encodedPattern.matcher(encodedPassword).matches();
     }
 }

--- a/backend/src/main/java/edonymyeon/backend/member/domain/PasswordValidator.java
+++ b/backend/src/main/java/edonymyeon/backend/member/domain/PasswordValidator.java
@@ -2,20 +2,30 @@ package edonymyeon.backend.member.domain;
 
 import java.util.Objects;
 import java.util.regex.Pattern;
+import org.apache.logging.log4j.util.Strings;
 
 public class PasswordValidator {
 
-    private PasswordValidator() {
-    }
-
     private static final String PASSWORD_PATTERN = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,30}$";
+    private static final String ENCODED_PATTERN = "^\\$.+\\$.+\\$.{64,}$";
 
     private static final Pattern passwordPattern = Pattern.compile(PASSWORD_PATTERN);
+    private static final Pattern encodedPattern = Pattern.compile(ENCODED_PATTERN);
+
+    private PasswordValidator() {
+    }
 
     public static boolean isValidPassword(String password) {
         if (Objects.isNull(password) || password.isBlank()) {
             return false;
         }
         return passwordPattern.matcher(password).matches();
+    }
+
+    public static boolean isEncodedPassword(String encodedPassword) {
+        if (Strings.isBlank(encodedPassword)) {
+            return false;
+        }
+        return encodedPattern.matcher(encodedPassword).matches();
     }
 }

--- a/backend/src/main/java/edonymyeon/backend/member/repository/MemberRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package edonymyeon.backend.member.repository;
 
 import edonymyeon.backend.member.domain.Member;
+import edonymyeon.backend.member.domain.Nickname;
 import edonymyeon.backend.member.domain.SocialInfo;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,5 +14,5 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberCus
 
     boolean existsByEmail(String email);
 
-    boolean existsByNickname(String nickname);
+    boolean existsByNickname(Nickname nickname);
 }

--- a/backend/src/main/java/edonymyeon/backend/member/repository/MemberRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/member/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package edonymyeon.backend.member.repository;
 
+import edonymyeon.backend.member.domain.Email;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.domain.Nickname;
 import edonymyeon.backend.member.domain.SocialInfo;
@@ -8,11 +9,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {
 
-    Optional<Member> findByEmail(final String email);
+    Optional<Member> findByEmail(final Email email);
 
     Optional<Member> findBySocialInfo(final SocialInfo socialInfo);
 
-    boolean existsByEmail(String email);
+    boolean existsByEmail(Email email);
 
     boolean existsByNickname(Nickname nickname);
 }

--- a/backend/src/test/java/edonymyeon/backend/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/auth/application/AuthServiceTest.java
@@ -22,6 +22,7 @@ import edonymyeon.backend.image.domain.ImageInfo;
 import edonymyeon.backend.image.profileimage.domain.ProfileImageInfo;
 import edonymyeon.backend.member.application.MemberService;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
+import edonymyeon.backend.member.domain.Email;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.domain.SocialInfo;
 import edonymyeon.backend.member.domain.SocialInfo.SocialType;
@@ -75,7 +76,7 @@ class AuthServiceTest {
                 new JoinRequest("test@gmail.com", "@testPassword234", "testNickname", "testDeviceToken"));
         final Member member = entityManager.createQuery(
                         "select m from Member m left join fetch m.devices where m.email = :email", Member.class)
-                .setParameter("email", "test@gmail.com")
+                .setParameter("email", Email.from("test@gmail.com"))
                 .getSingleResult();
         assertThat(member.getDevices()).hasSize(1);
     }

--- a/backend/src/test/java/edonymyeon/backend/consumption/docs/ConsumptionControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/consumption/docs/ConsumptionControllerDocsTest.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edonymyeon.backend.consumption.application.ConsumptionService;
 import edonymyeon.backend.consumption.application.dto.ConsumptionPriceResponse;
 import edonymyeon.backend.consumption.application.dto.RecentConsumptionsResponse;
+import edonymyeon.backend.member.domain.Email;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.support.DocsTest;
@@ -46,7 +47,7 @@ class ConsumptionControllerDocsTest extends DocsTest {
     }
 
     private void 회원_레포지토리를_모킹한다(final Member 회원) {
-        when(memberRepository.findByEmail(회원.getEmail())).thenReturn(Optional.of(회원));
+        when(memberRepository.findByEmail(Email.from(회원.getEmail()))).thenReturn(Optional.of(회원));
     }
 
     private void 소비_서비스를_모킹한다(final RecentConsumptionsResponse response) {

--- a/backend/src/test/java/edonymyeon/backend/member/docs/MemberControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/member/docs/MemberControllerDocsTest.java
@@ -33,6 +33,7 @@ import edonymyeon.backend.member.application.dto.request.SavingConfirmRequest;
 import edonymyeon.backend.member.application.dto.response.DuplicateCheckResponse;
 import edonymyeon.backend.member.application.dto.response.MyPageResponseV1_0;
 import edonymyeon.backend.member.application.dto.response.MyPageResponseV1_1;
+import edonymyeon.backend.member.domain.Email;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.domain.Post;
@@ -80,7 +81,7 @@ class MemberControllerDocsTest extends DocsTest {
     }
 
     private void 회원_레포지토리를_모킹한다(final Member 회원) {
-        when(memberRepository.findByEmail(회원.getEmail())).thenReturn(Optional.of(회원));
+        when(memberRepository.findByEmail(Email.from(회원.getEmail()))).thenReturn(Optional.of(회원));
     }
 
     private void 게시글_레포지토리를_모킹한다(final Post 게시글) {

--- a/backend/src/test/java/edonymyeon/backend/member/domain/EmailTest.java
+++ b/backend/src/test/java/edonymyeon/backend/member/domain/EmailTest.java
@@ -1,0 +1,51 @@
+package edonymyeon.backend.member.domain;
+
+import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_EMAIL_INVALID;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import edonymyeon.backend.global.exception.EdonymyeonException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class EmailTest {
+
+    @Test
+    void 이메일을_String으로_생성한다() {
+        //given
+        final String email = "email@test.com";
+
+        //when
+        //then
+        Assertions.assertDoesNotThrow(() -> Email.from(email));
+    }
+
+    @Test
+    void 이메일을_SocialType으로_생성한다() {
+        //given
+        final SocialInfo.SocialType socialType = SocialInfo.SocialType.KAKAO;
+
+        //when
+        //then
+        Assertions.assertDoesNotThrow(() -> Email.from(socialType));
+    }
+
+    @Test
+    void 이메일이_30글자를_초과하면_예외가_발생한다() {
+        //given
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 0; i < 31; i++) {
+            stringBuilder.append(i);
+        }
+        final String email = stringBuilder.toString();
+
+        //when
+        //then
+        assertThatThrownBy(() -> Email.from(email))
+                .isInstanceOf(EdonymyeonException.class)
+                .hasMessage(MEMBER_EMAIL_INVALID.getMessage());
+    }
+}

--- a/backend/src/test/java/edonymyeon/backend/member/domain/MemberTest.java
+++ b/backend/src/test/java/edonymyeon/backend/member/domain/MemberTest.java
@@ -1,12 +1,10 @@
 package edonymyeon.backend.member.domain;
 
-import static edonymyeon.backend.global.exception.ExceptionInformation.ENCODED_PASSWORD_INVALID;
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_EMAIL_INVALID;
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_NICKNAME_INVALID;
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_PASSWORD_INVALID;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import edonymyeon.backend.global.exception.BusinessLogicException;
 import edonymyeon.backend.global.exception.EdonymyeonException;
 import java.util.Collections;
 import java.util.List;
@@ -93,16 +91,6 @@ class MemberTest {
         final String previousNickname = member.getNickname();
         member.withdraw();
         Assertions.assertThat(member.getNickname()).isNotEqualTo(previousNickname);
-    }
-
-    @Test
-    void 비밀번호_암호화시_잘못_암호화된_비밀번호가_들어오면_예외발생() {
-        List<String> emptyList = Collections.emptyList();
-        final Member member = new Member("test@email.com", "password1234!", "nickname", null, emptyList);
-
-        assertThatThrownBy(() -> member.encrypt("이리내바보"))
-                .isInstanceOf(BusinessLogicException.class)
-                .hasMessage(ENCODED_PASSWORD_INVALID.getMessage());
     }
 
     @Test

--- a/backend/src/test/java/edonymyeon/backend/member/domain/MemberTest.java
+++ b/backend/src/test/java/edonymyeon/backend/member/domain/MemberTest.java
@@ -6,8 +6,6 @@ import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_NI
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_PASSWORD_INVALID;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import edonymyeon.backend.auth.domain.PasswordEncoder;
-import edonymyeon.backend.auth.domain.SimplePasswordEncoder;
 import edonymyeon.backend.global.exception.BusinessLogicException;
 import edonymyeon.backend.global.exception.EdonymyeonException;
 import java.util.Collections;
@@ -91,7 +89,7 @@ class MemberTest {
 
     @Test
     void 삭제하면_닉네임은_Unknown() {
-        final Member member = new Member();
+        final Member member = new Member("test@email.com", "password1234!", "nickname", null, Collections.emptyList());
         final String previousNickname = member.getNickname();
         member.withdraw();
         Assertions.assertThat(member.getNickname()).isNotEqualTo(previousNickname);

--- a/backend/src/test/java/edonymyeon/backend/member/domain/NicknameTest.java
+++ b/backend/src/test/java/edonymyeon/backend/member/domain/NicknameTest.java
@@ -1,0 +1,52 @@
+package edonymyeon.backend.member.domain;
+
+import static edonymyeon.backend.global.exception.ExceptionInformation.*;
+import static edonymyeon.backend.member.domain.SocialInfo.SocialType;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+
+import edonymyeon.backend.global.exception.EdonymyeonException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class NicknameTest {
+
+    @Test
+    void 닉네임을_String으로_생성한다() {
+        //given
+        final String nickname = "newNickname";
+
+        //when
+        //then
+        Assertions.assertDoesNotThrow(() -> Nickname.from(nickname));
+    }
+
+    @Test
+    void 닉네임을_SocialType으로_생성한다() {
+        //given
+        final SocialType socialType = SocialType.KAKAO;
+
+        //when
+        //then
+        Assertions.assertDoesNotThrow(() -> Nickname.from(socialType));
+    }
+
+    @Test
+    void 닉네임이_20글자를_초과하면_예외가_발생한다() {
+        //given
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 0; i < 21; i++) {
+            stringBuilder.append(i);
+        }
+        final String nickname = stringBuilder.toString();
+
+        //when
+        //then
+        assertThatThrownBy(() -> Nickname.from(nickname))
+                .isInstanceOf(EdonymyeonException.class)
+                .hasMessage(MEMBER_NICKNAME_INVALID.getMessage());
+    }
+}

--- a/backend/src/test/java/edonymyeon/backend/member/domain/PasswordTest.java
+++ b/backend/src/test/java/edonymyeon/backend/member/domain/PasswordTest.java
@@ -1,8 +1,11 @@
 package edonymyeon.backend.member.domain;
 
+import static edonymyeon.backend.global.exception.ExceptionInformation.ALREADY_ENCODED_PASSWORD;
 import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_PASSWORD_INVALID;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import edonymyeon.backend.auth.domain.SimplePasswordEncoder;
+import edonymyeon.backend.global.exception.BusinessLogicException;
 import edonymyeon.backend.global.exception.EdonymyeonException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -71,5 +74,19 @@ class PasswordTest {
         assertThatThrownBy(() -> Password.from(password))
                 .isInstanceOf(EdonymyeonException.class)
                 .hasMessage(MEMBER_PASSWORD_INVALID.getMessage());
+    }
+
+    @Test
+    void 이미_암호화된_비밀번호는_암호화될수없다() {
+        //given
+        final String input = "password1234!";
+        final Password password = Password.from(input);
+        final SimplePasswordEncoder encoder = new SimplePasswordEncoder();
+        final Password encryptedPassword = password.encrypt(encoder);
+        //when
+        //then
+        assertThatThrownBy(() -> encryptedPassword.encrypt(encoder))
+                .isInstanceOf(BusinessLogicException.class)
+                .hasMessage(ALREADY_ENCODED_PASSWORD.getMessage());
     }
 }

--- a/backend/src/test/java/edonymyeon/backend/member/domain/PasswordTest.java
+++ b/backend/src/test/java/edonymyeon/backend/member/domain/PasswordTest.java
@@ -1,0 +1,75 @@
+package edonymyeon.backend.member.domain;
+
+import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_PASSWORD_INVALID;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import edonymyeon.backend.global.exception.EdonymyeonException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class PasswordTest {
+
+    @Test
+    void 비밀번호를_String으로_생성한다() {
+        //given
+        final String password = "pass1234!";
+
+        //when
+        //then
+        Assertions.assertDoesNotThrow(() -> Password.from(password));
+    }
+
+    @Test
+    void 비밀번호를_SocialType으로_생성한다() {
+        //given
+        final SocialInfo.SocialType socialType = SocialInfo.SocialType.KAKAO;
+
+        //when
+        //then
+        Assertions.assertDoesNotThrow(() -> Password.from(socialType));
+    }
+
+    @Test
+    void 비밀번호가_8글자를_미만이면_예외가_발생한다() {
+        //given
+        final String password = "pass12!";
+
+        //when
+        //then
+        assertThatThrownBy(() -> Password.from(password))
+                .isInstanceOf(EdonymyeonException.class)
+                .hasMessage(MEMBER_PASSWORD_INVALID.getMessage());
+    }
+
+    @Test
+    void 비밀번호가_30글자를_초과하면_예외가_발생한다() {
+        //given
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 0; i < 31; i++) {
+            stringBuilder.append(i);
+        }
+        final String password = stringBuilder.toString();
+
+        //when
+        //then
+        assertThatThrownBy(() -> Password.from(password))
+                .isInstanceOf(EdonymyeonException.class)
+                .hasMessage(MEMBER_PASSWORD_INVALID.getMessage());
+    }
+
+    @Test
+    void 비밀번호가_형식이_맞지않으면_예외가_발생한다() {
+        //given
+        final String password = "password;%/?";
+
+        //when
+        //then
+        assertThatThrownBy(() -> Password.from(password))
+                .isInstanceOf(EdonymyeonException.class)
+                .hasMessage(MEMBER_PASSWORD_INVALID.getMessage());
+    }
+}

--- a/backend/src/test/java/edonymyeon/backend/post/docs/MyPostControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/docs/MyPostControllerDocsTest.java
@@ -18,6 +18,7 @@ import edonymyeon.backend.image.application.ImageService;
 import edonymyeon.backend.image.domain.ImageType;
 import edonymyeon.backend.image.domain.UrlManager;
 import edonymyeon.backend.image.postimage.domain.PostImageInfos;
+import edonymyeon.backend.member.domain.Email;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.application.GeneralFindingCondition;
@@ -139,7 +140,7 @@ class MyPostControllerDocsTest extends DocsTest {
     }
 
     private void 회원_레포지토리를_모킹한다(final Member 회원) {
-        when(memberRepository.findByEmail(회원.getEmail())).thenReturn(Optional.of(회원));
+        when(memberRepository.findByEmail(Email.from(회원.getEmail()))).thenReturn(Optional.of(회원));
         when(memberRepository.findById(회원.getId())).thenReturn(Optional.of(회원));
     }
 }

--- a/backend/src/test/java/edonymyeon/backend/post/docs/PostControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/docs/PostControllerDocsTest.java
@@ -26,6 +26,7 @@ import edonymyeon.backend.image.postimage.domain.PostImageInfo;
 import edonymyeon.backend.image.postimage.domain.PostImageInfos;
 import edonymyeon.backend.image.postimage.repository.PostImageInfoRepository;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
+import edonymyeon.backend.member.domain.Email;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.ImageFileCleaner;
@@ -89,7 +90,7 @@ class PostControllerDocsTest implements ImageFileCleaner {
     private PostThumbsServiceImpl postThumbsService;
 
     private void 회원_레포지토리를_모킹한다(final Member 회원) {
-        when(memberRepository.findByEmail(회원.getEmail())).thenReturn(
+        when(memberRepository.findByEmail(Email.from(회원.getEmail()))).thenReturn(
                 Optional.of(회원));
         when(memberRepository.findById(회원.getId())).thenReturn(Optional.of(회원));
     }

--- a/backend/src/test/java/edonymyeon/backend/report/docs/ReportDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/report/docs/ReportDocsTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edonymyeon.backend.image.postimage.domain.PostImageInfos;
+import edonymyeon.backend.member.domain.Email;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.ImageFileCleaner;
@@ -59,7 +60,7 @@ class ReportDocsTest implements ImageFileCleaner {
     private ReportRepository reportRepository;
 
     private void 회원_레포지토리를_모킹한다(final Member 회원) {
-        when(memberRepository.findByEmail(회원.getEmail())).thenReturn(
+        when(memberRepository.findByEmail(Email.from(회원.getEmail()))).thenReturn(
                 Optional.of(회원));
         when(memberRepository.findById(회원.getId())).thenReturn(Optional.of(회원));
     }

--- a/backend/src/test/java/edonymyeon/backend/support/TestMemberBuilder.java
+++ b/backend/src/test/java/edonymyeon/backend/support/TestMemberBuilder.java
@@ -107,8 +107,7 @@ public class TestMemberBuilder {
 
         private void encryptPassword(final Member member) {
             final SimplePasswordEncoder encoder = new SimplePasswordEncoder();
-            final String encodedPassword = encoder.encode(DEFAULT_PASSWORD);
-            member.encrypt(encodedPassword);
+            member.encrypt(encoder);
         }
 
         public Member buildWithoutSaving() {

--- a/backend/src/test/java/edonymyeon/backend/thumbs/docs/ThumbsControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/thumbs/docs/ThumbsControllerDocsTest.java
@@ -9,6 +9,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import edonymyeon.backend.member.domain.Email;
 import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.domain.Post;
@@ -62,14 +63,14 @@ class ThumbsControllerDocsTest {
                 .id(1L)
                 .buildWithoutSaving();
 
-        when(memberRepository.findByEmail(글쓴이.getEmail())).thenReturn(Optional.of(글쓴이));
+        when(memberRepository.findByEmail(Email.from(글쓴이.getEmail()))).thenReturn(Optional.of(글쓴이));
         when(memberRepository.findById(글쓴이.getId())).thenReturn(Optional.of(글쓴이));
 
         반응_하는_사람 = testMemberBuilder.builder()
                 .id(2L)
                 .buildWithoutSaving();
 
-        when(memberRepository.findByEmail(반응_하는_사람.getEmail())).thenReturn(
+        when(memberRepository.findByEmail(Email.from(반응_하는_사람.getEmail()))).thenReturn(
                 Optional.of(반응_하는_사람));
         when(memberRepository.findById(반응_하는_사람.getId())).thenReturn(Optional.of(반응_하는_사람));
 


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #523 

## 📝 작업 요약

회원 엔티티가 너무 무거워서 값 객체로 분리했습니다.
(205라인 -> 165라인 40라인 줄었슴다)

## 🔎 작업 상세 설명

Nickname, Email, Password 각각 값 객체로 분리하고 해당 역할을 분리하였습니다..

## 🌟 리뷰 요구 사항

> 크게 바뀐 건 없고 추가할 사항이나 잘못된 부분있는지 확인해주십쇼
