### PR TITLE
refactor/#415 글 삭제, 수정시 게시글 이미지의 soft delete를 위해 update문이 중복해서 나지 않도록 수정함

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/image/commentimage/repository/CommentImageInfoRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/image/commentimage/repository/CommentImageInfoRepository.java
@@ -1,18 +1,16 @@
 package edonymyeon.backend.image.commentimage.repository;
 
 import edonymyeon.backend.image.commentimage.domain.CommentImageInfo;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CommentImageInfoRepository extends JpaRepository<CommentImageInfo, Long> {
 
     @Modifying //todo: 옵션.. 이대로 괜찮은가?
     @Query("update CommentImageInfo c set c.deleted = true where c.id in :ids")
     void deleteAllById(@Param("ids") List<Long> ids);
-
-    @Query(value = "select * from comment_image_info", nativeQuery = true)
-    List<CommentImageInfo> findAllImages();
 }

--- a/backend/src/main/java/edonymyeon/backend/image/postimage/domain/PostImageInfo.java
+++ b/backend/src/main/java/edonymyeon/backend/image/postimage/domain/PostImageInfo.java
@@ -31,12 +31,6 @@ public class PostImageInfo extends ImageInfo {
     }
 
     public static PostImageInfo of(final ImageInfo imageInfo, final Post post) {
-        final PostImageInfo postImageInfo = new PostImageInfo(imageInfo.getStoreName(), post);
-        //post.addPostImageInfo(postImageInfo);
-        return postImageInfo;
-    }
-
-    public void delete() {
-        this.deleted = true;
+        return new PostImageInfo(imageInfo.getStoreName(), post);
     }
 }

--- a/backend/src/main/java/edonymyeon/backend/image/postimage/domain/PostImageInfos.java
+++ b/backend/src/main/java/edonymyeon/backend/image/postimage/domain/PostImageInfos.java
@@ -1,19 +1,20 @@
 package edonymyeon.backend.image.postimage.domain;
 
-import static edonymyeon.backend.global.exception.ExceptionInformation.IMAGE_STORE_NAME_INVALID;
-import static edonymyeon.backend.global.exception.ExceptionInformation.POST_IMAGE_COUNT_INVALID;
-
 import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.image.domain.ImageInfo;
 import edonymyeon.backend.post.domain.Post;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static edonymyeon.backend.global.exception.ExceptionInformation.IMAGE_STORE_NAME_INVALID;
+import static edonymyeon.backend.global.exception.ExceptionInformation.POST_IMAGE_COUNT_INVALID;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -53,11 +54,6 @@ public class PostImageInfos {
         return imageCount > MAX_IMAGE_COUNT;
     }
 
-    public void addAll(final List<PostImageInfo> imagesToAdd) {
-        validateImageCount(this.postImageInfos.size() + imagesToAdd.size());
-        this.postImageInfos.addAll(imagesToAdd);
-    }
-
     public void add(final PostImageInfo postImageInfo) {
         if (this.postImageInfos.contains(postImageInfo)) {
             return;
@@ -72,14 +68,14 @@ public class PostImageInfos {
         }
     }
 
-    public void update(final List<String> remainedStoreNames, final List<PostImageInfo> newPostImageInfos) {
+    public List<Long> getImageIdsToDeleteBy(final List<String> remainedStoreNames, final List<PostImageInfo> newPostImageInfos) {
         final List<PostImageInfo> imagesToDelete = findImagesToDelete(remainedStoreNames);
         int updatedImageCount = this.postImageInfos.size() - imagesToDelete.size() + newPostImageInfos.size();
         validateImageCount(updatedImageCount);
 
-        imagesToDelete.forEach(PostImageInfo::delete);
-        postImageInfos.removeAll(imagesToDelete);
-        postImageInfos.addAll(newPostImageInfos);
+        return imagesToDelete.stream()
+                .map(ImageInfo::getId)
+                .toList();
     }
 
     private List<PostImageInfo> findImagesToDelete(final List<String> remainedStoreNames) {
@@ -91,18 +87,6 @@ public class PostImageInfos {
             throw new EdonymyeonException(IMAGE_STORE_NAME_INVALID);
         }
         return unmatchedPostImageInfos;
-    }
-
-    // todo : 여기 부분 맞게 했나요? 헷갈립니다.
-    public void delete(final List<PostImageInfo> deletedPostImageInfos) {
-        // 어쨌든 deleted = false 인 놈들만 가지고 있어야 하니 지워져야 할 녀석들을 리스트에서 뺀다.
-        this.postImageInfos.removeAll(deletedPostImageInfos);
-        // 지워져야 하는 녀석들을 soft delete
-        deletedPostImageInfos.forEach(PostImageInfo::delete);
-    }
-
-    public void deleteAll() {
-        this.postImageInfos.forEach(PostImageInfo::delete);
     }
 
     public boolean isEmpty() {

--- a/backend/src/main/java/edonymyeon/backend/image/postimage/domain/PostImageInfos.java
+++ b/backend/src/main/java/edonymyeon/backend/image/postimage/domain/PostImageInfos.java
@@ -54,20 +54,6 @@ public class PostImageInfos {
         return imageCount > MAX_IMAGE_COUNT;
     }
 
-    public void add(final PostImageInfo postImageInfo) {
-        if (this.postImageInfos.contains(postImageInfo)) {
-            return;
-        }
-        validateImageAdditionCount();
-        this.postImageInfos.add(postImageInfo);
-    }
-
-    private void validateImageAdditionCount() {
-        if (isInvalidImageCount(this.postImageInfos.size() + 1)) {
-            throw new EdonymyeonException(POST_IMAGE_COUNT_INVALID);
-        }
-    }
-
     public List<Long> getImageIdsToDeleteBy(final List<String> remainedStoreNames, final List<PostImageInfo> newPostImageInfos) {
         final List<PostImageInfo> imagesToDelete = findImagesToDelete(remainedStoreNames);
         int updatedImageCount = this.postImageInfos.size() - imagesToDelete.size() + newPostImageInfos.size();

--- a/backend/src/main/java/edonymyeon/backend/image/postimage/repository/PostImageInfoRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/image/postimage/repository/PostImageInfoRepository.java
@@ -1,20 +1,22 @@
 package edonymyeon.backend.image.postimage.repository;
 
 import edonymyeon.backend.image.postimage.domain.PostImageInfo;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface PostImageInfoRepository extends JpaRepository<PostImageInfo, Long> {
 
     List<PostImageInfo> findAllByPostId(final Long postId);
 
     @Modifying
-    @Query("delete from PostImageInfo pi where pi.post.id=:postId")
+    @Query("update PostImageInfo pi set pi.deleted = true  where pi.post.id=:postId")
     void deleteAllByPostId(@Param("postId") final Long postId);
 
-    @Query(value = "select * from post_image_info", nativeQuery = true)
-    List<PostImageInfo> findAllImages();
+    @Modifying
+    @Query("update PostImageInfo pi set pi.deleted = true  where pi.id in (:imageIds)")
+    void deleteAllByIds(@Param("imageIds") final List<Long> imageIds);
 }

--- a/backend/src/main/java/edonymyeon/backend/image/profileimage/repository/ProfileImageInfoRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/image/profileimage/repository/ProfileImageInfoRepository.java
@@ -1,12 +1,8 @@
 package edonymyeon.backend.image.profileimage.repository;
 
 import edonymyeon.backend.image.profileimage.domain.ProfileImageInfo;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface ProfileImageInfoRepository extends JpaRepository<ProfileImageInfo, Long> {
 
-    @Query(value = "select * from profile_image_info", nativeQuery = true)
-    List<ProfileImageInfo> findAllImages();
 }

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
@@ -1,9 +1,5 @@
 package edonymyeon.backend.post.application;
 
-import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_ID_NOT_FOUND;
-import static edonymyeon.backend.global.exception.ExceptionInformation.POST_ID_NOT_FOUND;
-import static edonymyeon.backend.global.exception.ExceptionInformation.POST_MEMBER_NOT_SAME;
-
 import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.image.application.ImageService;
 import edonymyeon.backend.image.domain.ImageType;
@@ -18,13 +14,16 @@ import edonymyeon.backend.post.application.dto.response.PostIdResponse;
 import edonymyeon.backend.post.application.event.PostDeletionEvent;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;
-import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Objects;
+
+import static edonymyeon.backend.global.exception.ExceptionInformation.*;
 
 @RequiredArgsConstructor
 @Service
@@ -90,13 +89,12 @@ public class PostService {
         final Post post = findPostById(postId);
         checkWriter(member, post);
 
-        // soft delete 시킬 때, 실제 이미지는 보관된다.
-        // todo: 이미지 삭제.. 한번에..
         // todo: 소비내역 삭제할 때, 이벤트 대신 인터페이스로 변경
         applicationEventPublisher.publishEvent(new PostDeletionEvent(post.getId()));
         thumbsService.deleteAllThumbsInPost(postId);
         commentService.deleteAllCommentsInPost(postId);
         post.delete();
+        postImageInfoRepository.deleteAllByPostId(postId);
     }
 
     private Post findPostById(final Long postId) {
@@ -126,13 +124,18 @@ public class PostService {
         final List<String> remainedImageNames = imageService.convertToStoreName(request.originalImages(), ImageType.POST);
 
         if(isImagesEmpty(imageFilesToAdd)) {
-            post.updateImages(remainedImageNames);
+            final List<Long> imageIdsToDelete = post.getImageIdsToDeleteBy(remainedImageNames);
+            postImageInfoRepository.deleteAllByIds(imageIdsToDelete);
             return new PostIdResponse(postId);
         }
 
         final PostImageInfos imagesToAdd = PostImageInfos.of(post, imageService.saveAll(imageFilesToAdd, ImageType.POST));
-        post.updateImages(remainedImageNames, imagesToAdd); //이때 기존 이미지중 삭제되는 것들은 softDelete
+
+        final List<Long> imageIdsToDelete = post.getImageIdsToDeleteBy(remainedImageNames, imagesToAdd);
+        postImageInfoRepository.deleteAllByIds(imageIdsToDelete); //이때 기존 이미지중 삭제되는 것들은 softDelete
+
         postImageInfoRepository.saveAll(imagesToAdd.getPostImageInfos()); // //새로 추가된 이미지들을 DB에 저장
+
         return new PostIdResponse(postId);
     }
 }

--- a/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
+++ b/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
@@ -52,7 +52,6 @@ public class Post extends TemporalRecord {
     @JoinColumn(nullable = false)
     private Member member;
 
-    // TODO: cascade
     private PostImageInfos postImageInfos;
 
     @ColumnDefault("0")
@@ -125,6 +124,7 @@ public class Post extends TemporalRecord {
         }
     }
 
+    // todo: 이 부분 docs test에서만 쓰고 있어요
     public void addPostImageInfo(final PostImageInfo postImageInfo) {
         this.postImageInfos.add(postImageInfo);
     }
@@ -156,18 +156,16 @@ public class Post extends TemporalRecord {
 
     /**
      * 게시글 수정시 사용, 새로 추가되는 이미지가 없고 기존 이미지에 대한 수정만 일어나는 경우
-     * -> imageNamesToMaintain을 제외하고 삭제한다.
      */
-    public void updateImages(final List<String> remainedImageNames) {
-        postImageInfos.update(remainedImageNames, Collections.emptyList());
+    public List<Long> getImageIdsToDeleteBy(final List<String> remainedImageNames) {
+        return this.postImageInfos.getImageIdsToDeleteBy(remainedImageNames, Collections.emptyList());
     }
 
     /**
      * 게시글 수정시 사용, 새로 추가되는 이미지도 있는 경우
-     * -> imageNamesToMaintain을 제외하고 삭제 후, imagesToAdd를 추가한다.
      */
-    public void updateImages(final List<String> remainedImageNames, final PostImageInfos imagesToAdd) {
-        this.postImageInfos.update(remainedImageNames, imagesToAdd.getPostImageInfos());
+    public List<Long> getImageIdsToDeleteBy(final List<String> remainedImageNames, final PostImageInfos imagesToAdd) {
+        return this.postImageInfos.getImageIdsToDeleteBy(remainedImageNames, imagesToAdd.getPostImageInfos());
     }
 
     public boolean isSameMember(final Member member) {
@@ -179,7 +177,7 @@ public class Post extends TemporalRecord {
     }
 
     public Member getMember() {
-        return member;
+        return this.member;
     }
 
     public Long getWriterId() {
@@ -212,8 +210,6 @@ public class Post extends TemporalRecord {
     }
 
     public void delete() {
-        //lazyLoading 문제로 repository를 통해 직접 postImageInfos를 제거해주는 것이 필요하다.
-        this.postImageInfos.deleteAll();
         this.deleted = true;
     }
 

--- a/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
+++ b/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
@@ -124,11 +124,6 @@ public class Post extends TemporalRecord {
         }
     }
 
-    // todo: 이 부분 docs test에서만 쓰고 있어요
-    public void addPostImageInfo(final PostImageInfo postImageInfo) {
-        this.postImageInfos.add(postImageInfo);
-    }
-
     public void validateImageCount(final Integer imageCount) {
         this.postImageInfos.validateImageCount(imageCount);
     }

--- a/backend/src/test/java/edonymyeon/backend/post/docs/PostControllerDocsTest.java
+++ b/backend/src/test/java/edonymyeon/backend/post/docs/PostControllerDocsTest.java
@@ -1,28 +1,7 @@
 package edonymyeon.backend.post.docs;
 
-import static edonymyeon.backend.auth.ui.SessionConst.USER;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import edonymyeon.backend.CacheConfig;
-import edonymyeon.backend.image.postimage.domain.PostImageInfo;
+import edonymyeon.backend.image.domain.ImageInfo;
 import edonymyeon.backend.image.postimage.domain.PostImageInfos;
 import edonymyeon.backend.image.postimage.repository.PostImageInfoRepository;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
@@ -39,10 +18,6 @@ import edonymyeon.backend.support.IntegrationTest;
 import edonymyeon.backend.support.TestMemberBuilder;
 import edonymyeon.backend.thumbs.application.PostThumbsServiceImpl;
 import jakarta.servlet.http.Part;
-import java.nio.charset.StandardCharsets;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.apache.http.entity.ContentType;
 import org.junit.jupiter.api.Test;
@@ -54,7 +29,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -63,6 +37,24 @@ import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static edonymyeon.backend.auth.ui.SessionConst.USER;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SuppressWarnings("NonAsciiCharacters")
 @RequiredArgsConstructor
@@ -132,11 +124,11 @@ class PostControllerDocsTest implements ImageFileCleaner {
                 .id(1L)
                 .buildWithoutSaving();
 
-        final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 글쓴이);
-        final PostImageInfo 유지하는_이미지_정보 = new PostImageInfo("stay.jpg", 게시글);
-        final PostImageInfo 삭제될_이미지_정보 = new PostImageInfo("delete.jpg", 게시글);
-        게시글.addPostImageInfo(유지하는_이미지_정보);
-        게시글.addPostImageInfo(삭제될_이미지_정보);
+        final ImageInfo 유지하는_이미지_정보 = new ImageInfo("stay.jpg");
+        final ImageInfo 삭제될_이미지_정보 = new ImageInfo("delete.jpg");
+
+        final PostImageInfos postImageInfos = PostImageInfos.of(null, List.of(유지하는_이미지_정보, 삭제될_이미지_정보));
+        final Post 게시글 = new Post(1L, "제목", "내용", 1000L, 글쓴이, postImageInfos, 0,0, false);
 
         회원_레포지토리를_모킹한다(글쓴이);
         게시글_레포지토리를_모킹한다(게시글);


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #415 

## 📝 작업 요약

글 삭제, 수정시 게시글 이미지의 soft delete를 위해 update문이 중복해서 나지 않도록 수정함

## 🔎 작업 상세 설명

기존에 글의 사진을 삭제하거나 수정할 때 postImageInfo의 변경 감지를 이용하였기 때문에, update 쿼리가 중복해서 나가는 문제가 있었습니다. 
post.delete() 메서드 안에서 수행해주던 작업을 서비스 레이어에서 postImageInfo레포를 이용하여 하도록 수정하였습니다 ! 

<img width="379" alt="image" src="https://github.com/woowacourse-teams/2023-edonymyeon/assets/103317169/dccbbeac-f80f-4c7c-a0b5-1120352ab6ba">

## 🌟 리뷰 요구 사항

현재 게시글 삭제를 위해 postService에서 postImageInfo레포를 사용하고 있고
postImageInfo는 post를 들고 잇기 때문에 패키지간 양방향 의존이 생겼습니다 !
(comment Image도 마찬가지)
어떻게 해결하면 좋을지 같이 생각해주십시오G
