### PR TITLE
게시글 등록/ 수정시 이미지를 batch insert 하도록 수정함

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/image/postimage/repository/PostImageInfoCustomRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/image/postimage/repository/PostImageInfoCustomRepository.java
@@ -1,0 +1,10 @@
+package edonymyeon.backend.image.postimage.repository;
+
+import edonymyeon.backend.image.postimage.domain.PostImageInfo;
+
+import java.util.List;
+
+public interface PostImageInfoCustomRepository {
+
+    void batchSave(final List<PostImageInfo> imageInfos, final Long postId);
+}

--- a/backend/src/main/java/edonymyeon/backend/image/postimage/repository/PostImageInfoCustomRepositoryImpl.java
+++ b/backend/src/main/java/edonymyeon/backend/image/postimage/repository/PostImageInfoCustomRepositoryImpl.java
@@ -1,0 +1,36 @@
+package edonymyeon.backend.image.postimage.repository;
+
+import edonymyeon.backend.image.postimage.domain.PostImageInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class PostImageInfoCustomRepositoryImpl implements PostImageInfoCustomRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void batchSave(final List<PostImageInfo> imageInfos, final Long postId) {
+        final LocalDateTime now = LocalDateTime.now();
+        jdbcTemplate.batchUpdate("INSERT INTO post_image_info (created_at, post_id, store_name) values (?, ?, ?)",
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(final PreparedStatement ps, final int i) throws SQLException {
+                        ps.setObject(1, now);
+                        ps.setLong(2, postId);
+                        ps.setString(3, imageInfos.get(i).getStoreName());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return imageInfos.size();
+                    }
+                });
+    }
+}

--- a/backend/src/main/java/edonymyeon/backend/image/postimage/repository/PostImageInfoRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/image/postimage/repository/PostImageInfoRepository.java
@@ -1,13 +1,14 @@
 package edonymyeon.backend.image.postimage.repository;
 
 import edonymyeon.backend.image.postimage.domain.PostImageInfo;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface PostImageInfoRepository extends JpaRepository<PostImageInfo, Long> {
+import java.util.List;
+
+public interface PostImageInfoRepository extends JpaRepository<PostImageInfo, Long>, PostImageInfoCustomRepository {
 
     List<PostImageInfo> findAllByPostId(final Long postId);
 

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
@@ -25,11 +25,6 @@ import java.util.Objects;
 
 import static edonymyeon.backend.global.exception.ExceptionInformation.*;
 
-import java.util.List;
-import java.util.Objects;
-
-import static edonymyeon.backend.global.exception.ExceptionInformation.*;
-
 @RequiredArgsConstructor
 @Service
 public class PostService {
@@ -138,8 +133,7 @@ public class PostService {
 
         final List<Long> imageIdsToDelete = post.getImageIdsToDeleteBy(remainedImageNames, imagesToAdd);
         postImageInfoRepository.deleteAllByIds(imageIdsToDelete); //이때 기존 이미지중 삭제되는 것들은 softDelete
-
-        postImageInfoRepository.saveAll(imagesToAdd.getPostImageInfos()); // //새로 추가된 이미지들을 DB에 저장
+        postImageInfoRepository.batchSave(imagesToAdd.getPostImageInfos(), post.getId()); //새로 추가된 이미지들을 DB에 저장
 
         return new PostIdResponse(postId);
     }

--- a/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
+++ b/backend/src/main/java/edonymyeon/backend/post/application/PostService.java
@@ -1,9 +1,5 @@
 package edonymyeon.backend.post.application;
 
-import static edonymyeon.backend.global.exception.ExceptionInformation.MEMBER_ID_NOT_FOUND;
-import static edonymyeon.backend.global.exception.ExceptionInformation.POST_ID_NOT_FOUND;
-import static edonymyeon.backend.global.exception.ExceptionInformation.POST_MEMBER_NOT_SAME;
-
 import edonymyeon.backend.global.exception.EdonymyeonException;
 import edonymyeon.backend.image.application.ImageService;
 import edonymyeon.backend.image.domain.ImageType;
@@ -18,13 +14,16 @@ import edonymyeon.backend.post.application.dto.response.PostIdResponse;
 import edonymyeon.backend.post.application.event.PostDeletionEvent;
 import edonymyeon.backend.post.domain.Post;
 import edonymyeon.backend.post.repository.PostRepository;
-import java.util.List;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Objects;
+
+import static edonymyeon.backend.global.exception.ExceptionInformation.*;
 
 @RequiredArgsConstructor
 @Service
@@ -63,7 +62,7 @@ public class PostService {
 
         final PostImageInfos postImageInfos = PostImageInfos.of(post,
                 imageService.saveAll(postRequest.newImages(), ImageType.POST));
-        postImageInfoRepository.saveAll(postImageInfos.getPostImageInfos());
+        postImageInfoRepository.batchSave(postImageInfos.getPostImageInfos(), post.getId());
 
         return new PostIdResponse(post.getId());
     }
@@ -125,7 +124,7 @@ public class PostService {
         final List<MultipartFile> imageFilesToAdd = request.newImages();
         final List<String> remainedImageNames = imageService.convertToStoreName(request.originalImages(), ImageType.POST);
 
-        if(isImagesEmpty(imageFilesToAdd)) {
+        if (isImagesEmpty(imageFilesToAdd)) {
             post.updateImages(remainedImageNames);
             return new PostIdResponse(postId);
         }


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #527 

## 📝 작업 요약

이미지 업로드 후 이미지 정보들을 saveAll 해주던 것을 수정했습니다 !!
<img width="969" alt="스크린샷 2023-11-02 오후 9 57 18" src="https://github.com/woowacourse-teams/2023-edonymyeon/assets/103317169/c84856ad-6f1c-429f-8872-07d4ca22eede">
<img width="878" alt="스크린샷 2023-11-02 오후 9 58 41" src="https://github.com/woowacourse-teams/2023-edonymyeon/assets/103317169/4807e099-eb9f-4ebc-9bb7-61e48253aa28">

## 🌟 리뷰 요구 사항

아래 pr 머지되면 수정에서도 이 메서드를 사용하도록 바꿀 예정입니다 
