### PR TITLE
fix: 페이지를 새로고침이나 검색할 때마다 데이터가 없음을 보여주는 문구 오류 수정

### DIFF
--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/search/SearchFragment.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/main/search/SearchFragment.kt
@@ -16,7 +16,7 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class SearchFragment : BaseFragment<FragmentSearchBinding, SearchViewModel>(
-    { FragmentSearchBinding.inflate(it) }
+    { FragmentSearchBinding.inflate(it) },
 ) {
     override val viewModel: SearchViewModel by viewModels()
     override val inflater: LayoutInflater by lazy { LayoutInflater.from(context) }
@@ -41,10 +41,8 @@ class SearchFragment : BaseFragment<FragmentSearchBinding, SearchViewModel>(
 
         binding.rvSearchResult.adapter = searchAdapter
         viewModel.searchResult.observe(viewLifecycleOwner) {
-            binding.tvEmptyPost.isVisible = it.isEmpty()
-            if (it.isNotEmpty()) {
-                searchAdapter.setPosts(it)
-            }
+            searchAdapter.setPosts(it)
+            binding.tvEmptyPost.isVisible = it.isEmpty() && searchAdapter.itemCount == 0
         }
     }
 

--- a/android/app/src/main/java/com/app/edonymyeon/presentation/ui/mypost/MyPostActivity.kt
+++ b/android/app/src/main/java/com/app/edonymyeon/presentation/ui/mypost/MyPostActivity.kt
@@ -17,9 +17,11 @@ import com.app.edonymyeon.presentation.ui.postdetail.PostDetailActivity
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class MyPostActivity : BaseActivity<ActivityMyPostBinding, MyPostViewModel>(
-    { ActivityMyPostBinding.inflate(it) }
-), MyPostClickListener {
+class MyPostActivity :
+    BaseActivity<ActivityMyPostBinding, MyPostViewModel>(
+        { ActivityMyPostBinding.inflate(it) },
+    ),
+    MyPostClickListener {
     private val notificationId by lazy {
         intent.getLongExtra(KEY_NOTIFICATION_ID, -1)
     }
@@ -88,10 +90,8 @@ class MyPostActivity : BaseActivity<ActivityMyPostBinding, MyPostViewModel>(
 
     private fun setMyPostsObserver() {
         viewModel.posts.observe(this) {
-            binding.tvEmptyPost.isVisible = it.isEmpty()
-            if (it.isNotEmpty()) {
-                adapter.setMyPosts(it)
-            }
+            adapter.setMyPosts(it)
+            binding.tvEmptyPost.isVisible = it.isEmpty() && adapter.itemCount == 0
         }
     }
 


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #524 

## 📝 작업 요약

검색 페이지, 내가 쓴 글 페이지에서 데이터 없음을 보여주는 문구 오류 수정

## 🔎 작업 상세 설명

데이터를 observe해서 데이터가 없고 adapter itemCount도 0인 경우 문구가 보이도록 하였습니다!

## 🌟 리뷰 요구 사항

리뷰할 내용은 상세 설명한 부분이 다입니다!!
