### PR TITLE
fix: 로그인시 디바이스 활성화가 안되던 이슈 수정

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
+++ b/backend/src/main/java/edonymyeon/backend/auth/application/AuthService.java
@@ -51,6 +51,7 @@ public class AuthService {
      * @param loginRequest 로그인에 필요한 정보
      * @return 로그인한 사용자의 식별자
      */
+    @Transactional
     public MemberId login(final LoginRequest loginRequest) {
         final Member member = authenticateMember(loginRequest.email(), loginRequest.password());
         publisher.publishEvent(new LoginEvent(member, loginRequest.deviceToken()));


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #541 

클래스단에 달려있는 `@Transactional(readOnly = true)`가 자꾸 괴롭히는군용

카카오톡에서도 이야기를 했지만 메모를 해봅니다.
일단 login메서드에 `@Transactional` 어노테이션을 달아줌으로써 해결하긴 하였으나,
login 메서드에서는 이벤트를 제외하면 조회해서 체크하는 로직밖에 없기 때문에
과연 login메서드가 이벤트에서 쓰기연산이 발생할 일을 파악해서 `@Transactional`을 쓰도록 바꾸는 것이 맞는것인가?
하는 생각이 갑자기 들었습니다.
그렇다고 디바이스를 활성화/비활성화하는 메서드에 Require_new를 달자니 데드락이 걸리네요

결론: 이참에 `파사드 패턴`을 고려해보는 것이 어떨까요 ~