### PR TITLE
fix: 하나의 디바이스를 사용하는 회원 정보가 여러 개일 때, 로그아웃이 정상적으로 되지 않는 버그 해결

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/member/application/DeviceRepository.java
+++ b/backend/src/main/java/edonymyeon/backend/member/application/DeviceRepository.java
@@ -9,8 +9,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DeviceRepository extends JpaRepository<Device, Long> {
-    Optional<Device> findByDeviceToken(String deviceToken);
-
     @EntityGraph(attributePaths = "member")
     List<Device> findAllByDeviceToken(String deviceToken);
 

--- a/backend/src/main/java/edonymyeon/backend/member/application/MemberService.java
+++ b/backend/src/main/java/edonymyeon/backend/member/application/MemberService.java
@@ -188,7 +188,7 @@ public class MemberService {
 
     @Transactional
     public void deactivateDevice(final String deviceToken) {
-        final Optional<Device> device = deviceRepository.findByDeviceToken(deviceToken);
+        final Optional<Device> device = deviceRepository.findByDeviceTokenAndIsActiveIsTrue(deviceToken);
         device.ifPresent(Device::deactivate);
     }
 }

--- a/backend/src/test/java/edonymyeon/backend/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/auth/application/AuthServiceTest.java
@@ -32,6 +32,8 @@ import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.setting.application.SettingService;
 import edonymyeon.backend.support.IntegrationTest;
 import jakarta.persistence.EntityManager;
+
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.SoftAssertions;
@@ -128,11 +130,11 @@ class AuthServiceTest {
         //then
         assertSoftly(
                 softAssertions -> {
-                    final Device originalDevice = deviceRepository.findByDeviceToken(joinRequest.deviceToken()).get();
-                    final Optional<Device> changedDevice = deviceRepository.findByDeviceToken(loginRequest.deviceToken());
-                    assertThat(changedDevice.isPresent()).isTrue();
-                    assertThat(changedDevice.get().isActive()).isTrue();
-                    assertThat(originalDevice.isActive()).isFalse();
+                    final List<Device> originalDevice = deviceRepository.findAllByDeviceToken(joinRequest.deviceToken());
+                    final List<Device> changedDevice = deviceRepository.findAllByDeviceToken(loginRequest.deviceToken());
+                    assertThat(changedDevice).hasSize(1);
+                    assertThat(changedDevice.get(0).isActive()).isTrue();
+                    assertThat(originalDevice.get(0).isActive()).isFalse();
                 }
         );
     }
@@ -150,11 +152,11 @@ class AuthServiceTest {
         //then
         assertSoftly(
                 softAssertions -> {
-                    final Device originalDevice = deviceRepository.findByDeviceToken(originalDeviceToken).get();
-                    final Optional<Device> changedDevice = deviceRepository.findByDeviceToken(changedDeviceToken);
-                    assertThat(changedDevice.isPresent()).isTrue();
-                    assertThat(changedDevice.get().isActive()).isTrue();
-                    assertThat(originalDevice.isActive()).isFalse();
+                    final List<Device> originalDevice = deviceRepository.findAllByDeviceToken(originalDeviceToken);
+                    final List<Device> changedDevice = deviceRepository.findAllByDeviceToken(changedDeviceToken);
+                    assertThat(changedDevice).hasSize(1);
+                    assertThat(changedDevice.get(0).isActive()).isTrue();
+                    assertThat(originalDevice.get(0).isActive()).isFalse();
                 }
         );
     }

--- a/backend/src/test/java/edonymyeon/backend/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/member/application/MemberServiceTest.java
@@ -1,13 +1,5 @@
 package edonymyeon.backend.member.application;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.awaitility.Awaitility.await;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
-
 import edonymyeon.backend.auth.application.AuthService;
 import edonymyeon.backend.auth.application.dto.JoinRequest;
 import edonymyeon.backend.auth.application.dto.KakaoLoginResponse;
@@ -21,14 +13,20 @@ import edonymyeon.backend.member.domain.Member;
 import edonymyeon.backend.member.repository.MemberRepository;
 import edonymyeon.backend.post.ImageFileCleaner;
 import edonymyeon.backend.support.IntegrationFixture;
-import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.*;
 
 @SuppressWarnings("NonAsciiCharacters")
 @RequiredArgsConstructor
@@ -221,20 +219,5 @@ class MemberServiceTest extends IntegrationFixture implements ImageFileCleaner {
                     soft.assertThat(updatedMember.getNickname()).isNotEqualTo(updateRequest.nickname());
                 }
         );
-    }
-
-    @Test
-    @DisplayName("동일한 디바이스 정보가 여러 회원에 걸쳐 존재할 때에도 로그아웃이 정상 동작해야 한다.")
-    void deviceLogoutBug() {
-        // Given : 회원이 새로 가입하여 로그인한 후 로그아웃한다.
-        authService.joinMember(new JoinRequest(("test@gmail.com"), "password123!", "nickname", "sameDevice"));
-        authService.login(new LoginRequest("test@gmail.com", "password123!", "sameDevice"));
-        authService.logout("sameDevice");
-
-        // When : 동일한 디바이스를 가지고 새로운 회원이 가입하여 로그인한 후 로그아웃한다.
-        authService.joinMember(new JoinRequest(("test2@gmail.com"), "password123!", "nickname2", "sameDevice"));
-        authService.login(new LoginRequest("test2@gmail.com", "password123!", "sameDevice"));
-        assertThatCode(() -> authService.logout("sameDevice"))
-                .doesNotThrowAnyException();
     }
 }

--- a/backend/src/test/java/edonymyeon/backend/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/member/application/MemberServiceTest.java
@@ -1,7 +1,6 @@
 package edonymyeon.backend.member.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.any;
@@ -25,6 +24,7 @@ import edonymyeon.backend.support.IntegrationFixture;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.SpyBean;
@@ -221,5 +221,20 @@ class MemberServiceTest extends IntegrationFixture implements ImageFileCleaner {
                     soft.assertThat(updatedMember.getNickname()).isNotEqualTo(updateRequest.nickname());
                 }
         );
+    }
+
+    @Test
+    @DisplayName("동일한 디바이스 정보가 여러 회원에 걸쳐 존재할 때에도 로그아웃이 정상 동작해야 한다.")
+    void deviceLogoutBug() {
+        // Given : 회원이 새로 가입하여 로그인한 후 로그아웃한다.
+        authService.joinMember(new JoinRequest(("test@gmail.com"), "password123!", "nickname", "sameDevice"));
+        authService.login(new LoginRequest("test@gmail.com", "password123!", "sameDevice"));
+        authService.logout("sameDevice");
+
+        // When : 동일한 디바이스를 가지고 새로운 회원이 가입하여 로그인한 후 로그아웃한다.
+        authService.joinMember(new JoinRequest(("test2@gmail.com"), "password123!", "nickname2", "sameDevice"));
+        authService.login(new LoginRequest("test2@gmail.com", "password123!", "sameDevice"));
+        assertThatCode(() -> authService.logout("sameDevice"))
+                .doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #543 

## 📝 작업 요약

잘못된 디바이스 호출 방법으로 인해, 둘 이상의 회원이 동일한 디바이스로 로그인한 이력이 있는 경우 로그아웃이 일어나지 않는 버그가 발생했습니다.

## 🔎 작업 상세 설명

### 버그 발생 상황
1. A라는 디바이스 토큰으로 사용자가 회원가입 -> 로그인 -> 로그아웃 작업을 합니다.
2. 동일한 A 디바이스 토큰으로 다른 계정의 사용자가 회원가입 -> 로그인 -> 로그아웃 작업을 시도합니다.
3. findByDeviceToken의 결과 값이 2개이므로 NonUniqueResultException이 발생하면서 로그아웃에 실패합니다.

### 해결 방법
DeviceToken만을 where 조건으로 사용하는 findByDeviceToken 대신 '활성화된' 디바이스 정보를 가져오는 findByDeviceTokenAndIsActiveIsTrue 메소드를 사용하도록 변경함으로써 해결하였습니다.

## 🌟 리뷰 요구 사항

> 해당 시나리오를 확인하는 테스트코드를 작성했습니다. 간단히 확인하실 수 있을 거에요!
