### PR TITLE
Refactor/#548 notification 리팩토링

### DIFF
--- a/backend/src/main/java/edonymyeon/backend/comment/domain/Comment.java
+++ b/backend/src/main/java/edonymyeon/backend/comment/domain/Comment.java
@@ -87,10 +87,6 @@ public class Comment extends TemporalRecord {
         return commentImageInfo != null;
     }
 
-    public Optional<String> getDeviceTokenFromPostWriter() {
-        return this.post.getDeviceTokenFromWriter();
-    }
-
     public Long findPostId() {
         return this.post.getId();
     }

--- a/backend/src/main/java/edonymyeon/backend/global/exception/ExceptionInformation.java
+++ b/backend/src/main/java/edonymyeon/backend/global/exception/ExceptionInformation.java
@@ -46,6 +46,7 @@ public enum ExceptionInformation {
     MEMBER_IS_DELETED(3006, "삭제된 회원입니다."),
     MEMBER_SETTING_NOT_INITIALIZED(3007, "회원 설정 정보가 정상적으로 초기화되지 않았습니다."),
     MEMBER_SETTING_SERIAL_NOT_FOUNT(3010, "존재하지 않는 회원 설정입니다."),
+    MEMBER_DEVICE_TOKEN_NOT_FOUND(3011, "활성화된 디바이스 토큰이 존재하지 않습니다."),
 
     // 4___: 추천 관련
     THUMBS_UP_ALREADY_EXIST(4000, "이미 추천된 게시글 입니다."),

--- a/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
+++ b/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
@@ -87,10 +87,16 @@ public class Member extends TemporalRecord {
                 socialInfo);
     }
 
-    public Optional<String> getActiveDeviceToken() {
+    public boolean hasActiveDeviceToken() {
         return devices.stream().filter(Device::isActive)
                 .map(Device::getDeviceToken)
-                .findAny();
+                .findAny().isPresent();
+    }
+
+    public String getActiveDeviceToken() {
+        return devices.stream().filter(Device::isActive)
+                .map(Device::getDeviceToken)
+                .findAny().orElseThrow();
     }
 
     public void withdraw() {

--- a/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
+++ b/backend/src/main/java/edonymyeon/backend/member/domain/Member.java
@@ -2,6 +2,8 @@ package edonymyeon.backend.member.domain;
 
 import edonymyeon.backend.auth.domain.PasswordEncoder;
 import edonymyeon.backend.global.domain.TemporalRecord;
+import edonymyeon.backend.global.exception.EdonymyeonException;
+import edonymyeon.backend.global.exception.ExceptionInformation;
 import edonymyeon.backend.image.profileimage.domain.ProfileImageInfo;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embedded;
@@ -96,7 +98,7 @@ public class Member extends TemporalRecord {
     public String getActiveDeviceToken() {
         return devices.stream().filter(Device::isActive)
                 .map(Device::getDeviceToken)
-                .findAny().orElseThrow();
+                .findAny().orElseThrow(() -> new EdonymyeonException(ExceptionInformation.MEMBER_DEVICE_TOKEN_NOT_FOUND));
     }
 
     public void withdraw() {

--- a/backend/src/main/java/edonymyeon/backend/notification/application/NotificationService.java
+++ b/backend/src/main/java/edonymyeon/backend/notification/application/NotificationService.java
@@ -182,14 +182,10 @@ public class NotificationService {
                 deviceToken,
                 new Data(notificationId, notifyingType, redirectId)
         );
-        try {
-            notificationSender.sendNotification(
-                    receiver,
-                    notificationMessage.getMessage()
-            );
-        } catch (BusinessLogicException e) {
-            log.error("알림 전송에 실패했습니다.", e);
-        }
+        notificationSender.sendNotification(
+                receiver,
+                notificationMessage.getMessage()
+        );
     }
 
     /**

--- a/backend/src/main/java/edonymyeon/backend/notification/application/NotificationService.java
+++ b/backend/src/main/java/edonymyeon/backend/notification/application/NotificationService.java
@@ -150,20 +150,20 @@ public class NotificationService {
         final Long notificationId = saveNotification(notifyingTarget, notifyingType, redirectId, notificationMessage);
 
         final Optional<String> deviceToken = notifyingTarget.getActiveDeviceToken();
-        if (deviceToken.isEmpty()) {
-            return;
-        }
-
-        final Receiver receiver = new Receiver(notifyingTarget,
-                new Data(notificationId, notifyingType, redirectId));
-        try {
-            notificationSender.sendNotification(
-                    receiver,
-                    notificationMessage.getMessage()
+        deviceToken.ifPresent(token -> {
+            final Receiver receiver = new Receiver(
+                    deviceToken.get(),
+                    new Data(notificationId, notifyingType, redirectId)
             );
-        } catch (BusinessLogicException e) {
-            log.error("알림 전송에 실패했습니다.", e);
-        }
+            try {
+                notificationSender.sendNotification(
+                        receiver,
+                        notificationMessage.getMessage()
+                );
+            } catch (BusinessLogicException e) {
+                log.error("알림 전송에 실패했습니다.", e);
+            }
+        });
     }
 
     /**

--- a/backend/src/main/java/edonymyeon/backend/notification/application/NotificationService.java
+++ b/backend/src/main/java/edonymyeon/backend/notification/application/NotificationService.java
@@ -1,9 +1,5 @@
 package edonymyeon.backend.notification.application;
 
-import static edonymyeon.backend.notification.domain.NotificationMessage.COMMENT_NOTIFICATION_TITLE;
-import static edonymyeon.backend.notification.domain.NotificationMessage.THUMBS_NOTIFICATION_TITLE;
-import static edonymyeon.backend.notification.domain.NotificationMessage.THUMBS_PER_10_NOTIFICATION_TITLE;
-
 import edonymyeon.backend.comment.domain.Comment;
 import edonymyeon.backend.consumption.application.ConsumptionService;
 import edonymyeon.backend.global.exception.BusinessLogicException;
@@ -25,16 +21,18 @@ import edonymyeon.backend.setting.application.SettingService;
 import edonymyeon.backend.setting.domain.SettingType;
 import edonymyeon.backend.thumbs.application.ThumbsService;
 import jakarta.persistence.EntityManager;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Slice;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static edonymyeon.backend.notification.domain.NotificationMessage.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -57,7 +55,8 @@ public class NotificationService {
 
     /**
      * 특정 회원이 받은 알림 내역을 조회합니다.
-     * @param memberId 알림 내역을 조회할 회원의 식별자
+     *
+     * @param memberId         알림 내역을 조회할 회원의 식별자
      * @param findingCondition 페이징 조건
      * @return 페이징 처리된 알림 내역
      */
@@ -71,6 +70,7 @@ public class NotificationService {
 
     /**
      * 자신의 게시글에 누군가 추천/비추천을 남겼음을 알리는 알림을 발송합니다
+     *
      * @param post 추천/비추천이 달린 게시글
      */
     @Async
@@ -80,14 +80,15 @@ public class NotificationService {
             return;
         }
 
+        final Member writer = post.getMember();
         if (settingService.isSettingActive(new ActiveMemberId(post.getWriterId()), SettingType.NOTIFICATION_PER_10_THUMBS)
                 && isDivisibleBy10(thumbsService.countReactions(post.getId()))) {
-            sendNotification(post.getMember(), ScreenType.POST, post.getId(), THUMBS_PER_10_NOTIFICATION_TITLE);
+            sendNotification(writer, ScreenType.POST, post.getId(), THUMBS_PER_10_NOTIFICATION_TITLE);
             return;
         }
 
         if (settingService.isSettingActive(new ActiveMemberId(post.getWriterId()), SettingType.NOTIFICATION_PER_THUMBS)) {
-            sendNotification(post.getMember(), ScreenType.POST, post.getId(), THUMBS_NOTIFICATION_TITLE);
+            sendNotification(writer, ScreenType.POST, post.getId(), THUMBS_NOTIFICATION_TITLE);
         }
     }
 
@@ -97,6 +98,7 @@ public class NotificationService {
 
     /**
      * 자신의 게시글에 댓글이 달렸음을 알리는 알림을 발송합니다.
+     *
      * @param comment 게시글에 달린 댓글
      */
     @Async
@@ -106,10 +108,11 @@ public class NotificationService {
             return;
         }
 
+        final Member writer = comment.getPostWriter();
+
         if (settingService.isSettingActive(new ActiveMemberId(comment.getPost().getWriterId()), SettingType.NOTIFICATION_PER_COMMENT)) {
             comment = entityManager.merge(comment);
-
-            sendNotification(comment.getPostWriter(), ScreenType.POST, comment.findPostId(), COMMENT_NOTIFICATION_TITLE);
+            sendNotification(writer, ScreenType.POST, comment.findPostId(), COMMENT_NOTIFICATION_TITLE);
         }
     }
 
@@ -135,46 +138,75 @@ public class NotificationService {
     }
 
     /**
-     * 사용자에게 알림을 전송합니다.
-     * @param member 알림을 전송할 대상
-     * @param notifyingType 알림을 클릭했을 때 리다이렉트할 페이지의 종류
-     * @param redirectId 알림을 클릭했을 때 리다이렉트할 페이지의 id
+     * @param member              알림을 전송할 회원
+     * @param notifyingType       알림을 클릭했을 때 리다이렉트할 페이지의 종류
+     * @param redirectId          알림을 클릭했을 때 리다이렉트할 페이지의 id
      * @param notificationMessage 알림에서 표시할 제목
      */
-    private void sendNotification(final Member member, final ScreenType notifyingType, final Long redirectId,
-                                  final NotificationMessage notificationMessage) {
+    private void sendNotification(
+            final Member member,
+            final ScreenType notifyingType,
+            final Long redirectId,
+            final NotificationMessage notificationMessage
+    ) {
         if (member.isDeleted()) {
             return;
         }
 
-        final Long notificationId = saveNotification(member.getId(), notifyingType, redirectId, notificationMessage);
+        Long notificationId = saveNotification(member.getId(), notifyingType, redirectId, notificationMessage);
 
-        if (member.hasActiveDeviceToken()) {
-            final Receiver receiver = new Receiver(
-                    member.getActiveDeviceToken(),
-                    new Data(notificationId, notifyingType, redirectId)
+        if (!member.hasActiveDeviceToken()) {
+            return;
+        }
+
+        sendNotification(notificationId, member.getActiveDeviceToken(), notifyingType, redirectId, notificationMessage);
+    }
+
+    /**
+     * 사용자에게 알림을 전송합니다.
+     *
+     * @param notificationId      전송할 알림의 식별자
+     * @param deviceToken         알림을 전송할 디바이스 토큰
+     * @param notifyingType       알림을 클릭했을 때 리다이렉트할 페이지의 종류
+     * @param redirectId          알림을 클릭했을 때 리다이렉트할 페이지의 id
+     * @param notificationMessage 알림에서 표시할 제목
+     */
+    private void sendNotification(
+            final Long notificationId,
+            final String deviceToken,
+            final ScreenType notifyingType,
+            final Long redirectId,
+            final NotificationMessage notificationMessage
+    ) {
+        final Receiver receiver = new Receiver(
+                deviceToken,
+                new Data(notificationId, notifyingType, redirectId)
+        );
+        try {
+            notificationSender.sendNotification(
+                    receiver,
+                    notificationMessage.getMessage()
             );
-            try {
-                notificationSender.sendNotification(
-                        receiver,
-                        notificationMessage.getMessage()
-                );
-            } catch (BusinessLogicException e) {
-                log.error("알림 전송에 실패했습니다.", e);
-            }
+        } catch (BusinessLogicException e) {
+            log.error("알림 전송에 실패했습니다.", e);
         }
     }
 
     /**
      * 알림 전송 전/후 해당 내용을 저장합니다.
-     * @param memberId 알림을 전송받은 대상의 식별자
-     * @param notifyingType 알림을 클릭했을 때 리다이렉트한 페이지의 종류
-     * @param redirectId 알림을 클릭했을 때 리다이렉트한 페이지의 id
+     *
+     * @param memberId            알림을 전송받은 대상의 식별자
+     * @param notifyingType       알림을 클릭했을 때 리다이렉트한 페이지의 종류
+     * @param redirectId          알림을 클릭했을 때 리다이렉트한 페이지의 id
      * @param notificationMessage 알림에서 표시한 제목
      * @return 알림 식별자
      */
-    private Long saveNotification(final Long memberId, final ScreenType notifyingType, final Long redirectId,
-                          final NotificationMessage notificationMessage) {
+    private Long saveNotification(
+            final Long memberId,
+            final ScreenType notifyingType,
+            final Long redirectId,
+            final NotificationMessage notificationMessage
+    ) {
         final Notification notification = new Notification(
                 memberId,
                 notificationMessage.getMessage(),
@@ -186,6 +218,7 @@ public class NotificationService {
 
     /**
      * 알림을 '읽었음' 표시합니다.
+     *
      * @param notificationId '읽었음' 표시할 알림의 식별자
      */
     @Async
@@ -197,6 +230,7 @@ public class NotificationService {
 
     /**
      * 특정 게시글로부터 발생한 알림 내역을 전부 삭제합니다.
+     *
      * @param postId 게시글의 식별자
      */
     @Async

--- a/backend/src/main/java/edonymyeon/backend/notification/application/NotificationService.java
+++ b/backend/src/main/java/edonymyeon/backend/notification/application/NotificationService.java
@@ -136,23 +136,22 @@ public class NotificationService {
 
     /**
      * 사용자에게 알림을 전송합니다.
-     * @param notifyingTarget 알림을 전송할 대상
+     * @param member 알림을 전송할 대상
      * @param notifyingType 알림을 클릭했을 때 리다이렉트할 페이지의 종류
      * @param redirectId 알림을 클릭했을 때 리다이렉트할 페이지의 id
      * @param notificationMessage 알림에서 표시할 제목
      */
-    private void sendNotification(final Member notifyingTarget, final ScreenType notifyingType, final Long redirectId,
+    private void sendNotification(final Member member, final ScreenType notifyingType, final Long redirectId,
                                   final NotificationMessage notificationMessage) {
-        if (notifyingTarget.isDeleted()) {
+        if (member.isDeleted()) {
             return;
         }
 
-        final Long notificationId = saveNotification(notifyingTarget, notifyingType, redirectId, notificationMessage);
+        final Long notificationId = saveNotification(member, notifyingType, redirectId, notificationMessage);
 
-        final Optional<String> deviceToken = notifyingTarget.getActiveDeviceToken();
-        deviceToken.ifPresent(token -> {
+        if (member.hasActiveDeviceToken()) {
             final Receiver receiver = new Receiver(
-                    deviceToken.get(),
+                    member.getActiveDeviceToken(),
                     new Data(notificationId, notifyingType, redirectId)
             );
             try {
@@ -163,7 +162,7 @@ public class NotificationService {
             } catch (BusinessLogicException e) {
                 log.error("알림 전송에 실패했습니다.", e);
             }
-        });
+        }
     }
 
     /**

--- a/backend/src/main/java/edonymyeon/backend/notification/application/NotificationService.java
+++ b/backend/src/main/java/edonymyeon/backend/notification/application/NotificationService.java
@@ -147,7 +147,7 @@ public class NotificationService {
             return;
         }
 
-        final Long notificationId = saveNotification(member, notifyingType, redirectId, notificationMessage);
+        final Long notificationId = saveNotification(member.getId(), notifyingType, redirectId, notificationMessage);
 
         if (member.hasActiveDeviceToken()) {
             final Receiver receiver = new Receiver(
@@ -167,16 +167,16 @@ public class NotificationService {
 
     /**
      * 알림 전송 전/후 해당 내용을 저장합니다.
-     * @param notifyingTarget 알림을 전송받은 대상
+     * @param memberId 알림을 전송받은 대상의 식별자
      * @param notifyingType 알림을 클릭했을 때 리다이렉트한 페이지의 종류
      * @param redirectId 알림을 클릭했을 때 리다이렉트한 페이지의 id
      * @param notificationMessage 알림에서 표시한 제목
      * @return 알림 식별자
      */
-    private Long saveNotification(final Member notifyingTarget, final ScreenType notifyingType, final Long redirectId,
+    private Long saveNotification(final Long memberId, final ScreenType notifyingType, final Long redirectId,
                           final NotificationMessage notificationMessage) {
         final Notification notification = new Notification(
-                notifyingTarget,
+                memberId,
                 notificationMessage.getMessage(),
                 notifyingType,
                 redirectId

--- a/backend/src/main/java/edonymyeon/backend/notification/application/dto/Receiver.java
+++ b/backend/src/main/java/edonymyeon/backend/notification/application/dto/Receiver.java
@@ -1,16 +1,5 @@
 package edonymyeon.backend.notification.application.dto;
 
-import edonymyeon.backend.member.domain.Member;
-import lombok.Getter;
+public record Receiver(String token, Data data) {
 
-@Getter
-public class Receiver {
-
-    private final String token;
-    private final Data data;
-
-    public Receiver(final Member member, final Data data) {
-        this.token = member.getActiveDeviceToken().get();
-        this.data = data;
-    }
 }

--- a/backend/src/main/java/edonymyeon/backend/notification/domain/Notification.java
+++ b/backend/src/main/java/edonymyeon/backend/notification/domain/Notification.java
@@ -1,17 +1,7 @@
 package edonymyeon.backend.notification.domain;
 
 import edonymyeon.backend.global.domain.TemporalRecord;
-import edonymyeon.backend.member.domain.Member;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,9 +14,8 @@ public class Notification extends TemporalRecord {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false)
-    private Member member;
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
 
     private String title;
 
@@ -38,8 +27,8 @@ public class Notification extends TemporalRecord {
     @Column(name = "is_read")
     private boolean read;
 
-    public Notification(final Member member, final String title, final ScreenType screenType, final Long postId) {
-        this.member = member;
+    public Notification(final Long memberId, final String title, final ScreenType screenType, final Long postId) {
+        this.memberId = memberId;
         this.title = title;
         this.screenType = screenType;
         this.postId = postId;

--- a/backend/src/main/java/edonymyeon/backend/notification/infrastructure/FCMNotificationSender.java
+++ b/backend/src/main/java/edonymyeon/backend/notification/infrastructure/FCMNotificationSender.java
@@ -50,7 +50,7 @@ public class FCMNotificationSender implements NotificationSender {
     @Async
     public void sendNotification(final Receiver receiver, final String title) {
         try {
-            final String requestBody = makeFCMNotificationRequestBody(receiver.getToken(), title, receiver.getData());
+            final String requestBody = makeFCMNotificationRequestBody(receiver.token(), title, receiver.data());
             log.info("FCM 요청 발송 시작 - {}", requestBody);
             final OkHttpClient client = new OkHttpClient();
             final Request request = makeFCMNotificationRequest(requestBody);

--- a/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
+++ b/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
@@ -209,6 +209,6 @@ public class Post extends TemporalRecord {
     }
 
     public Optional<String> getDeviceTokenFromWriter() {
-        return this.member.getActiveDeviceToken();
+        return Optional.ofNullable(this.member.getActiveDeviceToken());
     }
 }

--- a/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
+++ b/backend/src/main/java/edonymyeon/backend/post/domain/Post.java
@@ -15,7 +15,6 @@ import org.hibernate.annotations.Where;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import static edonymyeon.backend.global.exception.ExceptionInformation.*;
 
@@ -206,9 +205,5 @@ public class Post extends TemporalRecord {
 
     public void delete() {
         this.deleted = true;
-    }
-
-    public Optional<String> getDeviceTokenFromWriter() {
-        return Optional.ofNullable(this.member.getActiveDeviceToken());
     }
 }

--- a/backend/src/test/java/edonymyeon/backend/notification/application/NotificationEventListenerTest.java
+++ b/backend/src/test/java/edonymyeon/backend/notification/application/NotificationEventListenerTest.java
@@ -102,7 +102,7 @@ class NotificationEventListenerTest extends IntegrationFixture {
                     template.execute(status -> {
                         final List<Notification> notifications = notificationRepository.findAll();
                         assertThat(notifications).hasSize(1);
-                        assertThat(notifications.get(0).getMember()).isEqualTo(writer);
+                        assertThat(notifications.get(0).getMemberId()).isEqualTo(writer.getId());
                         return "";
                     });
                 });

--- a/backend/src/test/java/edonymyeon/backend/notification/application/NotificationEventListenerTest.java
+++ b/backend/src/test/java/edonymyeon/backend/notification/application/NotificationEventListenerTest.java
@@ -107,32 +107,4 @@ class NotificationEventListenerTest extends IntegrationFixture {
                     });
                 });
     }
-
-    @Test
-    void 알림_전송_트랜잭션이_실패했다고_해서_따봉까지_롤백되어서는_안된다() {
-        doThrow(new BusinessLogicException(ExceptionInformation.NOTIFICATION_REQUEST_FAILED))
-                .when(notificationSender)
-                .sendNotification(any(), any());
-
-
-        final Member liker = 사용자를_하나_만든다();
-        final Member writer = authService.joinMember(new JoinRequest("test@gmail.com", "password123!", "backfoxxx", "testDevice123"));
-        final Post post = postTestSupport.builder().member(writer).build();
-        settingService.toggleSetting(SettingType.NOTIFICATION_PER_THUMBS.getSerialNumber(), new ActiveMemberId(writer.getId()));
-
-        thumbsService.thumbsUp(new ActiveMemberId(liker.getId()), post.getId());
-
-        await()
-                .atMost(Duration.ofSeconds(3))
-                .untilAsserted(() -> {
-                    assertThat(notificationRepository.findAll())
-                            .as("알림도 저장하고")
-                            .hasSize(1);
-
-                    final List<Thumbs> thumbs = thumbsRepository.findByPostId(post.getId());
-                    assertThat(thumbs)
-                            .as("따봉도 정상적으로 저장되어야 한다.")
-                            .hasSize(1);
-                });
-    }
 }

--- a/backend/src/test/java/edonymyeon/backend/notification/application/NotificationServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/notification/application/NotificationServiceTest.java
@@ -81,7 +81,7 @@ class NotificationServiceTest extends IntegrationFixture {
     void 특정_알림을_사용자가_읽었음을_체크할_수_있다() {
         final var post = postTestSupport.builder().build();
         final var notificationId = notificationRepository.save(
-                        new Notification(post.getMember(), "알림이 도착했어요!", ScreenType.POST, post.getId()))
+                        new Notification(post.getMember().getId(), "알림이 도착했어요!", ScreenType.POST, post.getId()))
                 .getId();
 
         var notification = notificationRepository.findById(notificationId);
@@ -291,7 +291,7 @@ class NotificationServiceTest extends IntegrationFixture {
         final Post post = postTestSupport.builder().member(writer).build();
 
         authService.login(new LoginRequest("test@gmail.com", "password123!",  "testDevice123"));
-        authService.logout(writer.getActiveDeviceToken().orElseGet(() -> fail("활성화된 디바이스 토큰이 존재하지 않음")));
+        authService.logout(writer.getActiveDeviceToken());
 
         commentService.createComment(new ActiveMemberId(commenter.getId()), post.getId(),
                 new CommentRequest(null, "Test Commentary"));

--- a/backend/src/test/java/edonymyeon/backend/notification/application/NotificationServiceTest.java
+++ b/backend/src/test/java/edonymyeon/backend/notification/application/NotificationServiceTest.java
@@ -1,22 +1,10 @@
 package edonymyeon.backend.notification.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.awaitility.Awaitility.await;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import edonymyeon.backend.auth.application.AuthService;
 import edonymyeon.backend.auth.application.dto.JoinRequest;
 import edonymyeon.backend.auth.application.dto.LoginRequest;
 import edonymyeon.backend.comment.application.CommentService;
 import edonymyeon.backend.comment.application.dto.request.CommentRequest;
-import edonymyeon.backend.global.exception.BusinessLogicException;
-import edonymyeon.backend.global.exception.ExceptionInformation;
 import edonymyeon.backend.member.application.MemberService;
 import edonymyeon.backend.member.application.dto.ActiveMemberId;
 import edonymyeon.backend.member.application.dto.request.PurchaseConfirmRequest;
@@ -30,11 +18,16 @@ import edonymyeon.backend.setting.application.SettingService;
 import edonymyeon.backend.setting.domain.SettingType;
 import edonymyeon.backend.support.IntegrationFixture;
 import edonymyeon.backend.thumbs.application.ThumbsService;
-import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.*;
 
 @SuppressWarnings("NonAsciiCharacters")
 @RequiredArgsConstructor
@@ -53,23 +46,6 @@ class NotificationServiceTest extends IntegrationFixture {
         final Member writer = getJoinedMember(authService);
         settingService.toggleSetting(SettingType.NOTIFICATION_PER_THUMBS.getSerialNumber(), new ActiveMemberId(writer.getId()));
         final Post post = postTestSupport.builder().member(writer).build();
-        notificationService.sendThumbsNotificationToWriter(post);
-
-        await()
-                .atMost(Duration.ofSeconds(3))
-                .untilAsserted(() -> assertThat(notificationRepository.findAll()).hasSize(1));
-    }
-
-    @Test
-    void 알림_전송에_실패해도_기록으로_남는다() {
-        final Member writer = getJoinedMember(authService);
-        settingService.toggleSetting(SettingType.NOTIFICATION_PER_THUMBS.getSerialNumber(), new ActiveMemberId(writer.getId()));
-        final Post post = postTestSupport.builder().member(writer).build();
-
-        doThrow(new BusinessLogicException(ExceptionInformation.NOTIFICATION_REQUEST_FAILED))
-                .when(notificationSender)
-                .sendNotification(any(), any());
-
         notificationService.sendThumbsNotificationToWriter(post);
 
         await()

--- a/backend/src/test/java/edonymyeon/backend/notification/integration/NotificationIntegrationTest.java
+++ b/backend/src/test/java/edonymyeon/backend/notification/integration/NotificationIntegrationTest.java
@@ -65,7 +65,7 @@ class NotificationIntegrationTest extends IntegrationFixture implements ImageFil
         final Member 사용자 = 사용자를_하나_만든다();
         final long 게시글id = 응답의_location헤더에서_id를_추출한다(게시글을_하나_만든다(사용자));
         final Long 알림id = notificationRepository
-                .save(new Notification(사용자, "알림이 등록되었어요!", ScreenType.POST, 게시글id))
+                .save(new Notification(사용자.getId(), "알림이 등록되었어요!", ScreenType.POST, 게시글id))
                 .getId();
 
         var notification = notificationRepository.findById(알림id);


### PR DESCRIPTION
## 🔥 연관 이슈

- close: #548 

## 📝 작업 요약

반려생활 면접 과정에서 CTO님과 함께 논의했던 리팩토링 포인트들을 반영했습니다.

## 🔎 작업 상세 설명

크게 3개의 개선 포인트를 찾아냈습니다.

* Receiver 객체의 파라미터로 엔티티 대신 필요한 정보만 뽑아 건네주어 테스트하기 쉬운 구조 만들기
-> Reciever에서는 회원의 토큰 정보만 필요로 하므로, 생성자로 Member 대신 토큰 문자열만 받도록 변경하여 Reciever와 Member의 의존관계를 끊어냈습니다.

* 디바이스 토큰이 존재하는지 검사하는 코드 개선하기
-> Optional 반환이 안티 패턴이라는 피드백을 받아 알아보았더니 일리가 있었습니다. 반환값이 Optional인 메서드에서 규칙을 무시하고 null을 반환한다면 optional.isEmpty() 같은 메서드를 호출하는 순간 NPE가 발생하기 떄문이었습니다.
그래서 deviceToken이 존재하는 지 확인하는 hasDeviceToken 메서드를 따로 만들고, getDeviceToken 메서드는 Optional 대신 값 원본을 리턴하도록 변경했습니다. 리턴값이 존재하지 않을 경우 예외가 발생합니다.

* 회원의 탈퇴 여부를 검증하는 코드를 대체할 수 있는 방안 찾기
-> 요건 해결하지 못했습니다! '탈퇴한 회원의 디바이스로 알림을 전송하지 않겠다' 라는 요구사항은 어떤 알림을 보내든 공통인데, sendNotification()에서 한 번에 관리하던 코드가 외부 코드에 분산되니 응집성이 너무 떨어져 정말 마음에 안 들더라구요 🥹
상태 별(회원가입 안됨, 회원가입 됨, 탈퇴함) 회원 객체를 만들어 사용하면 어떨까라는 건의를 인터뷰 중에 했었는데, 회원 도메인이 크게 변경되는 작업이라 별도의 이슈를 파서 작업해야 할 것 같아요!

## 🌟 리뷰 요구 사항

큰 변경이 없는 작업이라 빠르게 리뷰할 수 있을 거에요~